### PR TITLE
Make framework compatible with gemini-cli and claude code in planning research

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,9 +28,9 @@ Notes
 Most materials/chemistry simulation workflows involves the following steps:
 1. Create or query the relevent material structures.
 2. Prepare an accurate and efficient machine learning interatomic potential (mlip).
-    - You need to decide which mlip to use based on the rules under `.agent/skills/foundation-potentials/SKILL.md`
+    - You need to decide which mlip to use based on the rules under `.agents/skills/foundation-potentials/SKILL.md`
 3. Conduct multiple steps of simulations.
-    - You can find example workflows for common research tasks under `.agent/workflows/`
+    - You can find example workflows for common research tasks under `.agents/workflows/`
     - For workflows that are not privded, decompose it into sequence of SKILLs and MCP tools.
 
 
@@ -39,8 +39,8 @@ Most materials/chemistry simulation workflows involves the following steps:
 This project decomposes complex research tasks into three levels:
 
 - **Tools** (`src/mcp_server/`): Low-level operations exposed via MCP (relax structure, run MD, query databases). Strict typed I/O.
-- **Skills** (`.agents/skills/`): Mid-level tutorials combining tools and scripts to solve focused tasks (calculate melting point, run docking). Each has a `SKILL.md` with step-by-step instructions.
-- **Workflows** (`.agents/workflows/`): High-level research campaigns that chain multiple skills (e.g., screen for stable Li-ion conductors).
+- **Skills** (`.agentss/skills/`): Mid-level tutorials combining tools and scripts to solve focused tasks (calculate melting point, run docking). Each has a `SKILL.md` with step-by-step instructions.
+- **Workflows** (`.agentss/workflows/`): High-level research campaigns that chain multiple skills (e.g., screen for stable Li-ion conductors).
 
 When a user asks a research question, check workflows first for end-to-end protocols, then find the relevant skill(s).
 
@@ -50,7 +50,7 @@ Each skill subdirectory contains a `SKILL.md` with YAML frontmatter (`name`, `de
 
 **To find a relevant skill**, scan the frontmatter descriptions:
 ```bash
-grep -r "^description:" .agents/skills/*/SKILL.md
+grep -r "^description:" .agentss/skills/*/SKILL.md
 ```
 
 Then read the full `SKILL.md` for any matching skill and follow its numbered instructions.
@@ -63,7 +63,7 @@ Use the `/skill-search` command for interactive discovery: `/skill-search [searc
 Many skills reference helper scripts with environment annotations like:
 ```bash
 # Env: mace-agent
-python .agents/skills/mat-melting-point/scripts/create_interface.py ...
+python .agentss/skills/mat-melting-point/scripts/create_interface.py ...
 ```
 
 Activate the specified conda environment before running:
@@ -89,7 +89,7 @@ Skills that reference `mcp_*` functions (e.g., `mcp_mace_run_md()`) require MCP 
 
 ## Project Rules
 
-Development standards are documented in `.agents/rules/`:
+Development standards are documented in `.agentss/rules/`:
 - `skill-standards.md`: how to create and structure new skills
 - `coding-standards.md`: code style, testing, and dependencies
 - `mcp-environments.md`: environment-to-server mapping

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,4 +1,6 @@
-# AtomisticSkills: Claude Code Instructions
+# AtomisticSkills: Gemini CLI Instructions
+
+*This instruction is only for Gemini CLI.*
 
 ## Goal Overview
 
@@ -39,23 +41,23 @@ Most materials/chemistry simulation workflows involves the following steps:
 This project decomposes complex research tasks into three levels:
 
 - **Tools** (`src/mcp_server/`): Low-level operations exposed via MCP (relax structure, run MD, query databases). Strict typed I/O.
-- **Skills** (`.agents/skills/`): Mid-level tutorials combining tools and scripts to solve focused tasks (calculate melting point, run docking). Each has a `SKILL.md` with step-by-step instructions.
-- **Workflows** (`.agents/workflows/`): High-level research campaigns that chain multiple skills (e.g., screen for stable Li-ion conductors).
+- **Skills** (`.agent/skills/`): Mid-level tutorials combining tools and scripts to solve focused tasks (calculate melting point, run docking). Each has a `SKILL.md` with step-by-step instructions.
+- **Workflows** (`.agent/workflows/`): High-level research campaigns that chain multiple skills (e.g., screen for stable Li-ion conductors).
 
 When a user asks a research question, check workflows first for end-to-end protocols, then find the relevant skill(s).
 
 ## Skill Discovery
 
+Skills are located at `.agent/skills/`. Every subdirectory in this directory is a skill. 
+
 Each skill subdirectory contains a `SKILL.md` with YAML frontmatter (`name`, `description`, `category`) and numbered instructions.
 
 **To find a relevant skill**, scan the frontmatter descriptions:
 ```bash
-grep -r "^description:" .agents/skills/*/SKILL.md
+grep -r "^description:" .agent/skills/*/SKILL.md
 ```
 
 Then read the full `SKILL.md` for any matching skill and follow its numbered instructions.
-
-Use the `/skill-search` command for interactive discovery: `/skill-search [search term]`
 
 ## Executing Skills
 
@@ -63,15 +65,23 @@ Use the `/skill-search` command for interactive discovery: `/skill-search [searc
 Many skills reference helper scripts with environment annotations like:
 ```bash
 # Env: mace-agent
-python .agents/skills/mat-melting-point/scripts/create_interface.py ...
+python .agent/skills/mat-melting-point/scripts/create_interface.py ...
 ```
 
 Activate the specified conda environment before running:
+
 ```bash
 mamba activate <env-name>
 ```
 
+Or run by
+
+```bash
+conda run -n <env-name> python <path-to-py> [...]
+```
+
 ### MCP tool calls
+
 Skills that reference `mcp_*` functions (e.g., `mcp_mace_run_md()`) require MCP servers to be configured. If MCP servers are not available, check whether the underlying operation can be performed directly via scripts in the skill's `scripts/` directory or by importing from `src/utils/`.
 
 ## Environment Mapping
@@ -89,7 +99,8 @@ Skills that reference `mcp_*` functions (e.g., `mcp_mace_run_md()`) require MCP 
 
 ## Project Rules
 
-Development standards are documented in `.agents/rules/`:
+Development standards are documented in `.agent/rules/`:
+
 - `skill-standards.md`: how to create and structure new skills
 - `coding-standards.md`: code style, testing, and dependencies
 - `mcp-environments.md`: environment-to-server mapping
@@ -101,12 +112,12 @@ Skills that call `mcp_*` functions need MCP servers configured. You only need th
 
 1. Install the conda environment(s) you need (see `conda-envs/*/install.sh`)
 2. Open `mcp_config.json` for the server definitions
-3. Copy the entries you need into `~/.claude.json` under `"mcpServers"`
+3. Copy the entries you need into `~/.gemini/settings.json` under `"mcpServers"`
 4. Update the `command` path to point to your conda env's Python, e.g.:
    ```
-   "/Users/you/miniforge3/envs/mace-agent/bin/python"
+   "/home/you/miniforge3/envs/mace-agent/bin/python"
    ```
 5. Update the `PYTHONPATH` in `env` to your local clone path
-6. Restart Claude Code
+6. Restart Gemini CLI
 
 See `README.md` for full installation instructions.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -30,9 +30,9 @@ Notes
 Most materials/chemistry simulation workflows involves the following steps:
 1. Create or query the relevent material structures.
 2. Prepare an accurate and efficient machine learning interatomic potential (mlip).
-    - You need to decide which mlip to use based on the rules under `.agent/skills/foundation-potentials/SKILL.md`
+    - You need to decide which mlip to use based on the rules under `.agents/skills/foundation-potentials/SKILL.md`
 3. Conduct multiple steps of simulations.
-    - You can find example workflows for common research tasks under `.agent/workflows/`
+    - You can find example workflows for common research tasks under `.agents/workflows/`
     - For workflows that are not privded, decompose it into sequence of SKILLs and MCP tools.
 
 
@@ -41,20 +41,20 @@ Most materials/chemistry simulation workflows involves the following steps:
 This project decomposes complex research tasks into three levels:
 
 - **Tools** (`src/mcp_server/`): Low-level operations exposed via MCP (relax structure, run MD, query databases). Strict typed I/O.
-- **Skills** (`.agent/skills/`): Mid-level tutorials combining tools and scripts to solve focused tasks (calculate melting point, run docking). Each has a `SKILL.md` with step-by-step instructions.
-- **Workflows** (`.agent/workflows/`): High-level research campaigns that chain multiple skills (e.g., screen for stable Li-ion conductors).
+- **Skills** (`.agents/skills/`): Mid-level tutorials combining tools and scripts to solve focused tasks (calculate melting point, run docking). Each has a `SKILL.md` with step-by-step instructions.
+- **Workflows** (`.agents/workflows/`): High-level research campaigns that chain multiple skills (e.g., screen for stable Li-ion conductors).
 
 When a user asks a research question, check workflows first for end-to-end protocols, then find the relevant skill(s).
 
 ## Skill Discovery
 
-Skills are located at `.agent/skills/`. Every subdirectory in this directory is a skill. 
+Skills are located at `.agents/skills/`. Every subdirectory in this directory is a skill. 
 
 Each skill subdirectory contains a `SKILL.md` with YAML frontmatter (`name`, `description`, `category`) and numbered instructions.
 
 **To find a relevant skill**, scan the frontmatter descriptions:
 ```bash
-grep -r "^description:" .agent/skills/*/SKILL.md
+grep -r "^description:" .agents/skills/*/SKILL.md
 ```
 
 Then read the full `SKILL.md` for any matching skill and follow its numbered instructions.
@@ -65,7 +65,7 @@ Then read the full `SKILL.md` for any matching skill and follow its numbered ins
 Many skills reference helper scripts with environment annotations like:
 ```bash
 # Env: mace-agent
-python .agent/skills/mat-melting-point/scripts/create_interface.py ...
+python .agents/skills/mat-melting-point/scripts/create_interface.py ...
 ```
 
 Activate the specified conda environment before running:
@@ -99,7 +99,7 @@ Skills that reference `mcp_*` functions (e.g., `mcp_mace_run_md()`) require MCP 
 
 ## Project Rules
 
-Development standards are documented in `.agent/rules/`:
+Development standards are documented in `.agents/rules/`:
 
 - `skill-standards.md`: how to create and structure new skills
 - `coding-standards.md`: code style, testing, and dependencies


### PR DESCRIPTION
By directly injecting the entire text of `research-standards.md` to the system prompt, gemini-cli is able to have similar behavoir on making research plan as Antigravity.

Adjust system prompt to claude code in a similar mannar.
