### PR TITLE
Add uma-agent env, relax script, chem-db-mof skill; fix K_H numerics

### DIFF
--- a/.agents/skills/chem-db-mof/SKILL.md
+++ b/.agents/skills/chem-db-mof/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: chem-db-mof
+description: Query multiple MOF databases (QMOF via MPContribs; ARC-MOF DB7/Majumdar et al. via Zenodo) and download CIF structures with optional element or identifier filters.
+category: chemistry
+---
+
+# chem-db-mof
+
+## Goal
+
+Provide a unified interface for retrieving Metal-Organic Framework (MOF) crystal structures from multiple curated databases. Currently supported:
+
+| Database | Alias | Size | Access | Structures |
+|---|---|---|---|---|
+| Quantum MOF (QMOF) | `qmof` | ~20,000 DFT-relaxed | MPContribs API | DFT-optimized CIFs + bandgaps |
+| ARC-MOF DB7 (Majumdar et al.) | `arcmof-majumdar` | 12,316 hypothetical | Zenodo stream | CIFs with REPEAT partial charges |
+
+## Prerequisites
+
+- **Environment**: `base-agent`
+- **Packages**: `mpcontribs-client`, `requests`, `pandas`, `pymatgen`
+- **Credentials**: `MP_API_KEY` environment variable (required for `qmof` only)
+
+## Instructions
+
+### Step 1: Choose a database and set filters
+
+Decide which database to query and which element/identifier filters to apply.
+
+**For QMOF** — best for DFT-validated, experimentally-derived MOFs:
+- Use `--formula` for element filtering (e.g., `Zn` or `Cu,N,O`)
+- Use `--identifier` for a specific CSD refcode (e.g., `KAXQIL`)
+
+**For ARC-MOF DB7 (Majumdar et al.)** — best for diverse hypothetical MOFs with underrepresented inorganic SBUs:
+- Use `--elements` for element filtering (e.g., `Zn,O,C`)
+- Use `--identifier` for a specific structure ID (e.g., `DB7_00042`)
+- **First run**: downloads `geometric_properties.csv` (~110 MB) to `~/.cache/arcmof/` — one-time only; subsequent runs are fast
+
+### Step 2: Run the query
+
+```bash
+# Env: base-agent
+# QMOF — 10 Zn-containing MOFs
+MP_API_KEY=<your_key> python .agents/skills/chem-db-mof/scripts/query_mof_db.py \
+    --database qmof \
+    --formula Zn \
+    --max-results 10 \
+    --output-dir ./research/<date>_<task>/structures/qmof
+```
+
+```bash
+# Env: base-agent
+# ARC-MOF DB7 (Majumdar) — 20 Zn,O,C hypothetical MOFs
+python .agents/skills/chem-db-mof/scripts/query_mof_db.py \
+    --database arcmof-majumdar \
+    --elements Zn,O,C \
+    --max-results 20 \
+    --output-dir ./research/<date>_<task>/structures/arcmof_db7
+```
+
+```bash
+# Env: base-agent
+# ARC-MOF DB7 — retrieve a specific structure by identifier
+python .agents/skills/chem-db-mof/scripts/query_mof_db.py \
+    --database arcmof-majumdar \
+    --identifier DB7_00042 \
+    --output-dir ./research/<date>_<task>/structures/arcmof_db7
+```
+
+### Available Arguments
+
+| Argument | Applies to | Description |
+|---|---|---|
+| `--database` | both | `qmof` or `arcmof-majumdar` |
+| `--formula` | qmof | Element/formula filter string (e.g., `Zn,O,C`) |
+| `--elements` | arcmof-majumdar | Comma-separated required elements; ALL must be present |
+| `--identifier` | both | Specific structure name or ID substring |
+| `--max-results` | both | Max CIFs to download (default: 10) |
+| `--output-dir` | both | Directory for output CIF files |
+| `--cache-dir` | arcmof-majumdar | Override default cache `~/.cache/arcmof/` |
+
+### Step 3: Inspect outputs
+
+The script saves:
+- Individual `.cif` files named by structure identifier
+- `arcmof_db7_metadata.csv` (ARC-MOF only) — geometric properties for the downloaded subset
+
+Verify the download:
+```bash
+ls -lh <output-dir>/*.cif | head -20
+```
+
+## Download Behavior: ARC-MOF DB7
+
+The first call with `--database arcmof-majumdar` performs:
+
+1. **Metadata download** (~110 MB, one-time): `geometric_properties.csv` cached at `~/.cache/arcmof/`
+2. **DB7 filtering**: identifies the 12,316 Majumdar structures from the full 288k-entry CSV
+3. **CIF streaming**: streams the ARC-MOF tarball (`ARCMOF_20241004.tar.gz`, ~670 MB) and extracts only the requested CIFs — the stream is read once but only matching files are written to disk
+
+Subsequent runs with the same `--output-dir` skip already-downloaded CIFs.
+
+## Examples
+
+**Example 1: Query Zn MOFs from QMOF for CO₂ screening pre-processing**
+```bash
+# Env: base-agent
+MP_API_KEY=<your_mp_api_key> \
+python .agents/skills/chem-db-mof/scripts/query_mof_db.py \
+    --database qmof \
+    --formula Zn \
+    --max-results 10 \
+    --output-dir ./research/2026-03-27_test/qmof_zn
+```
+
+**Example 2: Query Zn, Ni, or Mg hypothetical MOFs from ARC-MOF DB7**
+```bash
+# Env: base-agent
+# Zn-based
+python .agents/skills/chem-db-mof/scripts/query_mof_db.py \
+    --database arcmof-majumdar \
+    --elements Zn,O,C \
+    --max-results 50 \
+    --output-dir ./research/2026-03-27_arcmof_zn
+
+# Ni-based
+python .agents/skills/chem-db-mof/scripts/query_mof_db.py \
+    --database arcmof-majumdar \
+    --elements Ni,O,C \
+    --max-results 50 \
+    --output-dir ./research/2026-03-27_arcmof_ni
+
+# Mg-based
+python .agents/skills/chem-db-mof/scripts/query_mof_db.py \
+    --database arcmof-majumdar \
+    --elements Mg,O,C \
+    --max-results 50 \
+    --output-dir ./research/2026-03-27_arcmof_mg
+```
+
+> **Tip:** You can expand diversity by adding more elements to `--elements` (e.g., `Zn,Ni,O,C,N` to retrieve MOFs containing all of those elements simultaneously), or run separate queries per metal node and combine the resulting CIF directories for a broader screening campaign.
+
+## Constraints
+
+- **API limits**: QMOF via MPContribs has rate limits; keep `--max-results` ≤ 100 per call.
+- **ARC-MOF first-run time**: Downloading the metadata CSV (~110 MB) takes ~1–2 min; streaming the tarball for CIF extraction adds ~5–15 min depending on how many structures are requested and network speed.
+- **ARC-MOF CIF fallback**: If some DB7 structures are not found in `ARCMOF_20241004.tar.gz`, they may reside in `all_structures_1.tar.gz` or `all_structures_2.tar.gz`. Update `ARCMOF_STRUCTURES_NAME` in the script if needed.
+- **Element filtering (ARC-MOF)**: Requires a `formula` or `chemical_formula` column in `geometric_properties.csv`. If the column is absent, all DB7 entries are returned without element filtering.
+- **Post-download**: Structures from ARC-MOF DB7 include REPEAT partial charges embedded in the CIF. These can be used directly for classical force-field simulations but should be relaxed with an MLIP before running Widom insertion (see [`chem-sorption-relax`](../chem-sorption-relax/SKILL.md)).
+
+## References
+
+- Raza, A. et al., "ARC–MOF: A Diverse Database of Metal-Organic Frameworks with DFT-Derived Partial Atomic Charges and Descriptors for Machine Learning", *Chem. Mater.*, 2022. [DOI: 10.1021/acs.chemmater.2c02485](https://doi.org/10.1021/acs.chemmater.2c02485)
+- Majumdar, S., Moosavi, S.M., Jablonka, K.M., Ongari, D., Smit, B., "Diversifying Databases of Metal Organic Frameworks for High-Throughput Computational Screening", *ACS Appl. Mater. Interfaces*, 2021. [DOI: 10.1021/acsami.1c16220](https://doi.org/10.1021/acsami.1c16220); dataset: *Materials Cloud Archive* 2021.126, [DOI: 10.24435/materialscloud:yn-de](https://doi.org/10.24435/materialscloud:yn-de)
+- Chung, Y.G. et al., "Computation-Ready, Experimental Metal-Organic Frameworks: A Tool To Enable High-Throughput Screening of Nanoporous Crystals", *Chem. Mater.*, 2014 (QMOF precursor). [DOI: 10.1021/cm502594j](https://doi.org/10.1021/cm502594j)
+- Rosen, A.S. et al., "Machine learning the quantum-chemical properties of metal-organic frameworks for accelerated materials discovery", *Matter*, 2021 (QMOF). [DOI: 10.1016/j.matt.2021.02.015](https://doi.org/10.1016/j.matt.2021.02.015)
+
+---
+
+**Author:** Sauradeep Majumdar
+**Contact:** [GitHub @sauradeep93](https://github.com/sauradeep93)

--- a/.agents/skills/chem-db-mof/scripts/query_mof_db.py
+++ b/.agents/skills/chem-db-mof/scripts/query_mof_db.py
@@ -1,0 +1,604 @@
+"""
+Unified MOF database query tool supporting QMOF and ARC-MOF (DB7/Majumdar subset).
+
+Supported databases:
+  qmof            - Quantum MOF database (~20,000 DFT-relaxed structures) via MPContribs
+  arcmof-majumdar - ARC-MOF DB7 subset (12,316 hypothetical MOFs, Majumdar et al. 2021)
+                    via Zenodo (DOI: 10.5281/zenodo.6908727)
+
+Usage:
+    python query_mof_db.py --database qmof --formula Zn --max-results 10 --output-dir ./results
+    python query_mof_db.py --database arcmof-majumdar --elements Zn,O,C --max-results 20 --output-dir ./results
+    python query_mof_db.py --database arcmof-majumdar --identifier MOFID-12345 --output-dir ./results
+
+Requirements:
+    - Conda environment: base-agent
+    - Required packages: requests, pandas, pymatgen, mpcontribs-client
+    - MP_API_KEY environment variable (for qmof only)
+"""
+
+import argparse
+import io
+import json
+import os
+import sys
+import tarfile
+from pathlib import Path
+
+import pandas as pd
+import requests
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+ARCMOF_ZENODO_RECORD = "6908727"
+ARCMOF_ZENODO_API = f"https://zenodo.org/api/records/{ARCMOF_ZENODO_RECORD}"
+
+# File basenames on Zenodo (confirmed from API listing)
+ARCMOF_GEOM_CSV_NAME = "geometric_properties.csv"
+ARCMOF_STRUCTURES_NAME = "ARCMOF_20241004.tar.gz"
+
+# Materials Cloud Archive — Majumdar et al. 2021 original data (149 MB, much smaller)
+# Used as the primary CIF source for arcmof-majumdar queries.
+MAJUMDAR_MATERIALS_CLOUD_URL = "https://archive.materialscloud.org/api/records/et2ts-zxh44/files/mof_data.tar.gz/content"
+MAJUMDAR_TARBALL_CACHE_NAME = "majumdar_mof_data.tar.gz"
+
+# Local cache directory — shared across runs to avoid repeated downloads
+DEFAULT_CACHE_DIR = Path.home() / ".cache" / "arcmof"
+
+# DB7 (Majumdar et al.) structure filename prefix in ARC-MOF
+ARCMOF_DB7_PREFIX = "DB7-"
+ARCMOF_DB7_SOURCE_LABELS = {"DB7", "Majumdar", "majumdar"}
+
+
+# ---------------------------------------------------------------------------
+# QMOF query (via MPContribs)
+# ---------------------------------------------------------------------------
+
+def query_qmof(formula: str | None, identifier: str | None, max_results: int, output_dir: Path) -> list[str]:
+    """
+    Query the QMOF database on Materials Project via MPContribs.
+
+    Args:
+        formula: Element filter string (e.g., "Zn,O,C").
+        identifier: CSD refcode or MOF name (e.g., "KAXQIL").
+        max_results: Maximum number of structures to download.
+        output_dir: Directory to save downloaded CIF files.
+
+    Returns:
+        List of saved CIF file paths.
+    """
+    try:
+        from mpcontribs.client import Client
+    except ImportError:
+        print("Error: mpcontribs-client is not installed. Run: pip install mpcontribs-client")
+        sys.exit(1)
+
+    api_key = os.environ.get("MP_API_KEY")
+    if not api_key:
+        print("Error: MP_API_KEY environment variable is not set.")
+        sys.exit(1)
+
+    print("Initializing MPContribs client for QMOF...")
+    client = Client(api_key, project="qmof")
+
+    query: dict = {}
+    if formula:
+        query["formula__contains"] = formula
+    if identifier:
+        query["identifier__contains"] = identifier
+
+    print(f"Querying QMOF with: {query or '(no filter — returning first results)'}")
+    try:
+        results = client.contributions.queryContributions(
+            project="qmof",
+            _fields=["id", "identifier", "formula", "structures"],
+            _limit=max_results,
+            **query,
+        ).result()
+    except Exception as e:
+        print(f"Failed to query MPContribs: {e}")
+        sys.exit(1)
+
+    if not results or "data" not in results or len(results["data"]) == 0:
+        print("No matching MOFs found in QMOF database.")
+        return []
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    saved = []
+    print(f"Found {len(results['data'])} MOFs. Downloading CIFs to {output_dir}...")
+
+    for contrib in results["data"]:
+        contrib_id = contrib["id"]
+        identifier_name = contrib["identifier"]
+        formula_name = contrib["formula"]
+        print(f"  {identifier_name} ({formula_name})")
+
+        if "structures" not in contrib or not contrib["structures"]:
+            print(f"    No structures available for {identifier_name}.")
+            continue
+
+        structure_id = contrib["structures"][0]["id"]
+        try:
+            structure_data = client.structures.getStructureById(
+                pk=structure_id,
+                _fields=["cif"],
+            ).result()
+            cif_string = structure_data.get("cif")
+            if cif_string:
+                filepath = output_dir / f"{identifier_name}.cif"
+                filepath.write_text(cif_string)
+                saved.append(str(filepath))
+                print(f"    Saved: {filepath}")
+            else:
+                print(f"    No CIF data for {identifier_name}.")
+        except Exception as e:
+            print(f"    Error downloading {identifier_name}: {e}")
+
+    return saved
+
+
+# ---------------------------------------------------------------------------
+# ARC-MOF DB7 (Majumdar et al.) query via Zenodo
+# ---------------------------------------------------------------------------
+
+def _get_zenodo_file_url(filename: str) -> str:
+    """
+    Fetch the download URL for a specific file from the ARC-MOF Zenodo record
+    via the Zenodo REST API. This handles version redirects automatically.
+    """
+    print(f"Resolving Zenodo download URL for '{filename}' ...")
+    resp = requests.get(ARCMOF_ZENODO_API, timeout=30)
+    resp.raise_for_status()
+    record = resp.json()
+    for f in record.get("files", []):
+        if f.get("key") == filename:
+            url = f["links"]["self"]
+            print(f"  Resolved: {url}")
+            return url
+    raise FileNotFoundError(
+        f"'{filename}' not found in Zenodo record {ARCMOF_ZENODO_RECORD}. "
+        f"Available files: {[f['key'] for f in record.get('files', [])]}"
+    )
+
+
+def _download_arcmof_metadata(cache_dir: Path) -> pd.DataFrame:
+    """
+    Download and cache geometric_properties.csv from ARC-MOF Zenodo record.
+    Returns a DataFrame with all entries.
+    """
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    csv_cache = cache_dir / ARCMOF_GEOM_CSV_NAME
+
+    if csv_cache.exists():
+        print(f"Using cached metadata: {csv_cache}")
+    else:
+        url = _get_zenodo_file_url(ARCMOF_GEOM_CSV_NAME)
+        print(f"Downloading ARC-MOF metadata CSV (~110 MB) to {csv_cache} ...")
+        print("(This is a one-time download; subsequent runs use the cache.)")
+        with requests.get(url, stream=True, timeout=300) as r:
+            r.raise_for_status()
+            total = int(r.headers.get("content-length", 0))
+            downloaded = 0
+            with open(csv_cache, "wb") as f:
+                for chunk in r.iter_content(chunk_size=1 << 20):  # 1 MB chunks
+                    f.write(chunk)
+                    downloaded += len(chunk)
+                    if total:
+                        pct = 100 * downloaded / total
+                        print(f"\r  {downloaded / 1e6:.1f} / {total / 1e6:.1f} MB ({pct:.0f}%)", end="", flush=True)
+        print()
+        print("Metadata download complete.")
+
+    df = pd.read_csv(csv_cache, low_memory=False)
+    return df
+
+
+def _identify_db7_source_column(df: pd.DataFrame) -> str | None:
+    """
+    Detect the column in the ARC-MOF CSV that identifies the source database.
+    Returns the column name or None if not found.
+    """
+    # Common column names used in ARC-MOF papers
+    for candidate in ["source_db", "source", "database", "db", "origin", "Source_DB", "Database"]:
+        if candidate in df.columns:
+            return candidate
+    return None
+
+
+def _filter_db7(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Filter the metadata DataFrame for DB7 (Majumdar et al.) structures.
+    Primary strategy: match the 'DB7-' filename prefix in the identifier column.
+    Fallback: match a source_db column if present.
+    """
+    id_col = _detect_id_column(df)
+
+    # Primary: filename prefix "DB7-" (confirmed naming convention in ARC-MOF)
+    if id_col:
+        mask = df[id_col].astype(str).str.startswith(ARCMOF_DB7_PREFIX)
+        db7 = df[mask].copy()
+        if not db7.empty:
+            print(f"Found {len(db7)} DB7 (Majumdar) entries via prefix '{ARCMOF_DB7_PREFIX}' in column '{id_col}'.")
+            return db7
+
+    # Fallback: source database column
+    source_col = _identify_db7_source_column(df)
+    if source_col:
+        mask = df[source_col].astype(str).str.strip().isin(ARCMOF_DB7_SOURCE_LABELS)
+        db7 = df[mask].copy()
+        if not db7.empty:
+            print(f"Found {len(db7)} DB7 (Majumdar) entries via column '{source_col}'.")
+            return db7
+
+    print("Warning: Could not identify DB7 structures. Inspect CSV columns:")
+    print(list(df.columns[:20]))
+    if id_col:
+        print(f"Sample values in '{id_col}':", df[id_col].head(5).tolist())
+    sys.exit(1)
+
+
+def _detect_id_column(df: pd.DataFrame) -> str | None:
+    """Find the column that holds MOF structure identifiers."""
+    for candidate in ["MOFid", "mofid", "name", "id", "structure_id", "filename", "ID"]:
+        if candidate in df.columns:
+            return candidate
+    # Fall back to first column
+    return df.columns[0] if len(df.columns) > 0 else None
+
+
+def _filter_by_elements(df: pd.DataFrame, elements: list[str], id_col: str) -> pd.DataFrame:
+    """
+    Filter structures to those containing ALL specified elements.
+    Uses the identifier string or a formula column if available.
+    """
+    if not elements:
+        return df
+
+    formula_col = None
+    for candidate in ["formula", "chemical_formula", "Formula"]:
+        if candidate in df.columns:
+            formula_col = candidate
+            break
+
+    if formula_col:
+        mask = pd.Series([True] * len(df), index=df.index)
+        for el in elements:
+            mask &= df[formula_col].astype(str).str.contains(el, regex=False)
+        result = df[mask]
+        print(f"After element filter {elements}: {len(result)} structures.")
+        return result
+    else:
+        print(f"Warning: no formula column found; cannot filter by elements {elements}. Returning all DB7 entries.")
+        return df
+
+
+def _elements_from_cif_bytes(cif_bytes: bytes) -> set[str]:
+    """
+    Extract element symbols from CIF file content by parsing the
+    _atom_site_type_symbol loop. Falls back to _atom_site_label parsing.
+    This avoids a full pymatgen CifParser call for speed.
+    """
+    import re
+    text = cif_bytes.decode("utf-8", errors="ignore")
+
+    # Look for _atom_site_type_symbol values (most reliable)
+    symbols = re.findall(r"_atom_site_type_symbol\s+([\s\S]+?)(?=_atom_site|\Z)", text)
+    if symbols:
+        raw = symbols[0].split()
+        elements = {re.sub(r"[^A-Za-z]", "", s).capitalize() for s in raw if s and not s.startswith("_")}
+        elements = {e for e in elements if e.isalpha() and len(e) <= 2}
+        if elements:
+            return elements
+
+    # Fallback: _atom_site_label (strip trailing digits/signs)
+    labels = re.findall(r"^\s*([A-Z][a-z]?\d*[+-]?)\s", text, re.MULTILINE)
+    elements = {re.sub(r"[^A-Za-z]", "", l).capitalize() for l in labels}
+    return {e for e in elements if e.isalpha() and 1 <= len(e) <= 2}
+
+
+def _download_majumdar_tarball(cache_dir: Path) -> Path:
+    """
+    Download and cache the Majumdar et al. mof_data.tar.gz from Materials Cloud
+    (149 MB, one-time). Returns the path to the cached tarball.
+    """
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    tarball_path = cache_dir / MAJUMDAR_TARBALL_CACHE_NAME
+
+    if tarball_path.exists():
+        print(f"Using cached Majumdar tarball: {tarball_path}")
+        return tarball_path
+
+    print(f"Downloading Majumdar et al. CIF archive (~149 MB) from Materials Cloud ...")
+    print("(One-time download; subsequent runs use the cache.)")
+    with requests.get(MAJUMDAR_MATERIALS_CLOUD_URL, stream=True, timeout=600) as r:
+        r.raise_for_status()
+        total = int(r.headers.get("content-length", 0))
+        downloaded = 0
+        with open(tarball_path, "wb") as f:
+            for chunk in r.iter_content(chunk_size=1 << 20):
+                f.write(chunk)
+                downloaded += len(chunk)
+                if total:
+                    pct = 100 * downloaded / total
+                    print(f"\r  {downloaded / 1e6:.1f} / {total / 1e6:.1f} MB ({pct:.0f}%)", end="", flush=True)
+    print()
+    print("Majumdar tarball download complete.")
+    return tarball_path
+
+
+def _load_majumdar_metadata(tarball_path: Path) -> pd.DataFrame:
+    """
+    Extract mof_data.csv from the Majumdar tarball.
+    Contains MOF_name, metal_node, topology, and precomputed CO2/H2 adsorption properties.
+    """
+    with tarfile.open(tarball_path, "r:gz") as tar:
+        f = tar.extractfile("mof_data/mof_data.csv")
+        df = pd.read_csv(f)
+    return df
+
+
+def _extract_majumdar_cifs(
+    output_dir: Path,
+    cache_dir: Path,
+    max_results: int,
+    metals: list[str],
+    identifier: str | None,
+) -> list[str]:
+    """
+    Extract CIFs from the Majumdar et al. Materials Cloud tarball.
+
+    Tarball structure:
+      majumdar_mof_data.tar.gz
+        mof_data/mof_data.csv           ← metadata + CO2 properties
+        mof_data/mof_structures.tar     ← nested uncompressed tar with CIFs
+          ddmof_cifs/ddmof_XXXXX.cif
+
+    Workflow:
+      1. Download and cache the tarball (one-time, ~149 MB).
+      2. Optionally filter by identifier substring.
+      3. Stream through the nested mof_structures.tar, parsing element symbols
+         from _atom_site_type_symbol in each CIF to apply metal filter.
+      4. Save matching CIFs and write metadata CSV for the downloaded subset.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Skip already-downloaded CIFs in the output dir
+    existing = [str(p) for p in output_dir.glob("*.cif")]
+    if len(existing) >= max_results:
+        print(f"{len(existing)} CIFs already present (>= max_results={max_results}); skipping.")
+        return existing[:max_results]
+
+    tarball_path = _download_majumdar_tarball(cache_dir)
+
+    # Load metadata CSV for output summary
+    print("Loading mof_data.csv metadata ...")
+    meta_df = _load_majumdar_metadata(tarball_path)
+    meta_df["MOF_name"] = meta_df["MOF_name"].str.replace(".cif", "", regex=False)
+
+    required_metals = {m.capitalize() for m in metals}
+    saved_paths = list(existing)
+    saved_stems: set[str] = {Path(p).stem for p in existing}
+    saved_meta_rows: list[dict] = []
+
+    print(f"Extracting CIFs from nested mof_structures.tar ...")
+    if required_metals:
+        print(f"  Metal filter (at least one required): {sorted(required_metals)}")
+    if identifier:
+        print(f"  Identifier filter: '{identifier}'")
+
+    checked = 0
+    with tarfile.open(tarball_path, "r:gz") as outer:
+        inner_f = outer.extractfile("mof_data/mof_structures.tar")
+        with tarfile.open(fileobj=inner_f, mode="r:") as inner:
+            for member in inner:
+                if not member.isfile() or not member.name.endswith(".cif"):
+                    continue
+
+                stem = Path(member.name).stem
+                if stem in saved_stems:
+                    continue
+
+                # Identifier filter
+                if identifier and identifier.lower() not in stem.lower():
+                    continue
+
+                f = inner.extractfile(member)
+                if f is None:
+                    continue
+
+                cif_bytes = f.read()
+                checked += 1
+
+                # Metal element filter — parsed from CIF _atom_site_type_symbol
+                if required_metals:
+                    found = _elements_from_cif_bytes(cif_bytes)
+                    # Require at least one of the requested metals to be present
+                    if not required_metals.intersection(found):
+                        continue
+
+                out_path = output_dir / f"{stem}.cif"
+                out_path.write_bytes(cif_bytes)
+                saved_paths.append(str(out_path))
+                saved_stems.add(stem)
+
+                # Collect metadata row
+                row = meta_df[meta_df["MOF_name"] == stem]
+                if not row.empty:
+                    saved_meta_rows.append(row.iloc[0].to_dict())
+
+                print(f"  [{len(saved_paths)}] {stem}.cif")
+                if len(saved_paths) >= max_results:
+                    break
+
+    print(f"Done. Checked {checked} CIFs, saved {len(saved_paths)} to {output_dir}.")
+
+    # Save metadata summary for the downloaded subset
+    if saved_meta_rows:
+        meta_out = output_dir / "majumdar_metadata.csv"
+        pd.DataFrame(saved_meta_rows).to_csv(meta_out, index=False)
+        print(f"Metadata (incl. CO2 uptake, selectivity) saved: {meta_out}")
+
+    if len(saved_paths) < max_results and not identifier:
+        print(f"Note: only {len(saved_paths)} CIFs matched the filter across all {checked} checked.")
+
+    return saved_paths[:max_results]
+
+
+class _StreamWrapper(io.RawIOBase):
+    """Wraps a requests streaming response as a readable file-like object for tarfile."""
+
+    def __init__(self, response: requests.Response):
+        self._iter = response.iter_content(chunk_size=1 << 16)  # 64 KB
+        self._buf = b""
+
+    def read(self, n: int = -1) -> bytes:
+        if n < 0:
+            return b"".join(self._iter)
+        while len(self._buf) < n:
+            try:
+                self._buf += next(self._iter)
+            except StopIteration:
+                break
+        out, self._buf = self._buf[:n], self._buf[n:]
+        return out
+
+    def readable(self) -> bool:
+        return True
+
+
+def query_arcmof_majumdar(
+    elements: list[str],
+    identifier: str | None,
+    max_results: int,
+    output_dir: Path,
+    cache_dir: Path,
+) -> list[str]:
+    """
+    Query the ARC-MOF DB7 (Majumdar et al. 2021) subset.
+
+    Workflow:
+      1. Download mof_data.tar.gz from Materials Cloud (149 MB, cached after first run).
+      2. Stream through CIFs, filtering by element composition on-the-fly from CIF content.
+      3. Optionally also download geometric_properties.csv from Zenodo for metadata.
+
+    CIF source: Materials Cloud Archive record 2021.126 (original Majumdar data, 12,316 structures).
+    Element filtering: parsed from _atom_site_type_symbol in each CIF — no formula CSV needed.
+
+    Args:
+        elements: List of required elements (e.g., ["Zn", "O", "C"]).
+        identifier: Specific structure name/ID substring to retrieve.
+        max_results: Maximum number of CIFs to download.
+        output_dir: Directory to save CIF files.
+        cache_dir: Local cache directory for downloaded archives.
+
+    Returns:
+        List of saved CIF file paths.
+    """
+    return _extract_majumdar_cifs(
+        output_dir=output_dir,
+        cache_dir=cache_dir,
+        max_results=max_results,
+        metals=elements,
+        identifier=identifier,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Query MOF databases (QMOF or ARC-MOF DB7/Majumdar) and download CIF structures.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # 10 Zn-containing MOFs from QMOF
+  python query_mof_db.py --database qmof --formula Zn --max-results 10 --output-dir ./results/qmof
+
+  # 20 Zn,O,C MOFs from ARC-MOF DB7 (Majumdar subset)
+  python query_mof_db.py --database arcmof-majumdar --elements Zn,O,C --max-results 20 --output-dir ./results/arcmof
+
+  # Specific structure by identifier from ARC-MOF DB7
+  python query_mof_db.py --database arcmof-majumdar --identifier DB7_00042 --output-dir ./results/arcmof
+        """,
+    )
+    parser.add_argument(
+        "--database",
+        type=str,
+        choices=["qmof", "arcmof-majumdar"],
+        required=True,
+        help="Which MOF database to query.",
+    )
+    parser.add_argument(
+        "--formula",
+        type=str,
+        default=None,
+        help="[QMOF only] Element/formula filter string (e.g., 'Zn' or 'Zn,O,C').",
+    )
+    parser.add_argument(
+        "--elements",
+        type=str,
+        default=None,
+        help="[arcmof-majumdar] Comma-separated metal elements to filter by (e.g., 'Zn', 'Ni', 'Mg', or 'Zn,Ni'). "
+             "Structures containing AT LEAST ONE of the listed metals are returned. "
+             "Parsed from _atom_site_type_symbol in each CIF. "
+             "Add more metals to broaden diversity (e.g., 'Zn,Ni,Mg,Cu,Fe').",
+    )
+    parser.add_argument(
+        "--identifier",
+        type=str,
+        default=None,
+        help="Specific structure name or ID substring to retrieve (e.g., 'KAXQIL' for QMOF, "
+             "'DB7_00042' for ARC-MOF).",
+    )
+    parser.add_argument(
+        "--max-results",
+        type=int,
+        default=10,
+        help="Maximum number of CIF structures to download (default: 10).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="./mof_results",
+        help="Directory to save downloaded CIF files (default: ./mof_results).",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=str,
+        default=str(DEFAULT_CACHE_DIR),
+        help=f"Local cache directory for ARC-MOF metadata (default: {DEFAULT_CACHE_DIR}).",
+    )
+
+    args = parser.parse_args()
+    output_dir = Path(args.output_dir)
+    cache_dir = Path(args.cache_dir)
+
+    if args.database == "qmof":
+        saved = query_qmof(
+            formula=args.formula,
+            identifier=args.identifier,
+            max_results=args.max_results,
+            output_dir=output_dir,
+        )
+
+    elif args.database == "arcmof-majumdar":
+        elements = [e.strip() for e in args.elements.split(",")] if args.elements else []
+        saved = query_arcmof_majumdar(
+            elements=elements,
+            identifier=args.identifier,
+            max_results=args.max_results,
+            output_dir=output_dir,
+            cache_dir=cache_dir,
+        )
+
+    print(f"\nDone. {len(saved)} CIF(s) saved to {output_dir}.")
+    for p in saved:
+        print(f"  {p}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/chem-sorption-relax/SKILL.md
+++ b/.agents/skills/chem-sorption-relax/SKILL.md
@@ -31,22 +31,54 @@ python .agents/skills/chem-sorption-relax/scripts/build_supercell.py \
 > [!TIP]
 > If the script output indicates a `1x1x1` supercell was created (i.e. no expansion needed), you can just use your original CIF or the output CIF, as they will be identical. 
 
-2. **Relax the Framework**: Use the appropriate MLIP MCP relaxation tool to relax the (supercell) framework. Save the results to an output directory.
+2. **Relax the Framework**: Two options depending on which model/env you need:
 
+**Option A — MCP Tool (fairchem-agent env, named models: uma-s-1p1, uma-m-1p1)**
 ```python
-# Example MCP Tool Call for FairChem UMA
+# Env: fairchem-agent (via MCP server)
 mcp_fairchem_relax_structure(
     structure_data="./out/framework_supercell.cif",
     fmax=0.05,
-    steps=1000,
+    steps=500,
     optimizer="LBFGS",
     relax_cell=True,
     output_dir="./out/relaxed_framework"
 )
 ```
 
-3. **Proceed to downstream tasks**: 
-The relaxed CIF file (e.g. `./out/relaxed_framework/framework_supercell.cif`) from step 2 is now ready for use in [chem-sorption-widom](../chem-sorption-widom/SKILL.md) and [chem-sorption-gcmc](../chem-sorption-gcmc/SKILL.md).
+**Option B — Script (uma-agent env, checkpoint path, e.g. uma-s-1p2.pt)**
+
+Use this when the MCP env does not support the required checkpoint (e.g. uma-s-1p2 requires fairchem ≥ 2.18).
+
+```bash
+# Env: uma-agent  (fairchem >= 2.18, supports uma-s-1p2.pt)
+PYTHONPATH=/path/to/AtomisticSkills mamba run -n uma-agent \
+    python .agents/skills/chem-sorption-relax/scripts/relax_structure.py \
+    --structure ./out/framework_supercell.cif \
+    --name MY_FRAMEWORK \
+    --calculator fairchem \
+    --model-name /path/to/uma-s-1p2.pt \
+    --task-name omol \
+    --fmax 0.05 \
+    --steps 500 \
+    --optimizer LBFGS \
+    --output-dir ./out/relaxed_framework
+```
+
+### relax_structure.py Parameters
+- `--structure`: Path to input CIF or XYZ.
+- `--name`: Identifier used in output filenames.
+- `--calculator`: Backend MLIP (`fairchem`, `mace`, `matgl`).
+- `--model-name`: Named model (e.g. `uma-s-1p1`) or full path to checkpoint (e.g. `/path/to/uma-s-1p2.pt`).
+- `--task-name`: Multi-task head (`omol`, `omat`, `odac`, `oc20`, `omc`).
+- `--optimizer`: `LBFGS` (default) or `FIRE`.
+- `--fmax`: Force convergence threshold in eV/Å (default: 0.05).
+- `--steps`: Maximum optimizer steps (default: 500).
+- `--relax-cell`: Relax unit cell (default: True). Use `--fixed-cell` to fix cell.
+- `--output-dir`: Directory to save `<name>.relaxed.cif` and `relax_results.json`.
+
+3. **Proceed to downstream tasks**:
+The relaxed CIF file (e.g. `./out/relaxed_framework/<name>.relaxed.cif`) from step 2 is now ready for use in [chem-sorption-widom](../chem-sorption-widom/SKILL.md) and [chem-sorption-gcmc](../chem-sorption-gcmc/SKILL.md).
 
 ## Examples
 
@@ -61,15 +93,29 @@ python .agents/skills/chem-sorption-relax/scripts/build_supercell.py \
     --output-cif ./results/COF-1_supercell.cif
 ```
 
-2. Relax with UMA via MCP Tool:
+2a. Relax with UMA-S-1p1 via MCP Tool:
 ```python
 mcp_fairchem_relax_structure(
     structure_data="./results/COF-1_supercell.cif",
     fmax=0.05,
-    steps=1000,
+    steps=500,
     optimizer="LBFGS",
     output_dir="./results/relaxed"
 )
+```
+
+2b. Relax with UMA-S-1p2 via script (uma-agent env):
+```bash
+# Env: uma
+PYTHONPATH=/home/user/AtomisticSkills mamba run -n uma-agent \
+    python .agents/skills/chem-sorption-relax/scripts/relax_structure.py \
+    --structure ./results/COF-1_supercell.cif \
+    --name COF-1 \
+    --calculator fairchem \
+    --model-name ~/models/checkpoints/uma-s-1p2.pt \
+    --task-name omol \
+    --fmax 0.05 --steps 500 \
+    --output-dir ./results/relaxed/COF-1
 ```
 
 ## Constraints
@@ -79,5 +125,5 @@ mcp_fairchem_relax_structure(
 
 ---
 
-**Author:** Artur Lyssenko  
-**Contact:** [GitHub @arturlyssenko12](https://github.com/arturlyssenko12)
+**Authors:** Artur Lyssenko, Sauradeep Majumdar
+**Contact:** [GitHub @arturlyssenko12](https://github.com/arturlyssenko12), [GitHub @sauradeep93](https://github.com/sauradeep93)

--- a/.agents/skills/chem-sorption-relax/scripts/relax_structure.py
+++ b/.agents/skills/chem-sorption-relax/scripts/relax_structure.py
@@ -1,0 +1,183 @@
+"""
+Relax a porous framework (CIF/XYZ) using any supported MLIP backend via AtomisticSkills.
+
+Usage:
+    python relax_structure.py --structure path/to/supercell.cif --name MOF-1 \\
+        --calculator fairchem --model-name /path/to/uma-s-1p2.pt --task-name omol \\
+        --fmax 0.05 --steps 500 --output-dir ./relaxed/MOF-1
+
+Requirements:
+    - Env: depends on --calculator
+        fairchem + file path  -> use 'uma' conda env (fairchem 2.18.1)
+        fairchem named model  -> use 'fairchem-agent' conda env
+        mace                  -> use 'mace-agent' conda env
+        matgl                 -> use 'matgl-agent' conda env
+    - PYTHONPATH must include AtomisticSkills project root so src.utils is importable.
+"""
+
+from pathlib import Path
+import argparse
+import json
+import sys
+
+# Add project root so src.utils is importable
+_project_root = Path(__file__).resolve().parents[4]
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
+from ase.io import read, write
+from ase.optimize import LBFGS, FIRE
+from ase.filters import FrechetCellFilter
+
+from src.utils.mlips.loader import load_wrapper
+
+
+def select_device(device: str) -> str:
+    if device == "auto":
+        import torch
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    return device
+
+
+def normalize_charge_spin(atoms) -> None:
+    info = atoms.info if isinstance(atoms.info, dict) else {}
+    if atoms.info is not info:
+        atoms.info = info
+    try:
+        charge = int(info.get("charge", info.get("chg", 0)))
+    except Exception:
+        charge = 0
+    try:
+        spin_mult = int(
+            info.get("spin_multiplicity", info.get("multiplicity", info.get("spin", 1)))
+        )
+    except Exception:
+        spin_mult = 1
+    atoms.info["charge"] = charge
+    atoms.info["spin_multiplicity"] = spin_mult
+    atoms.info["spin"] = spin_mult
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Relax a framework structure using a generic MLIP calculator.")
+    p.add_argument("--structure", type=Path, required=True, help="Input structure (.cif or .xyz)")
+    p.add_argument("--name", type=str, required=True, help="Identifier for output files")
+    p.add_argument(
+        "--calculator",
+        type=str,
+        required=True,
+        choices=["mace", "fairchem", "matgl"],
+        help="Backend MLIP calculator to use.",
+    )
+    p.add_argument("--model-name", type=str, required=True, help="Model name or path to checkpoint")
+    p.add_argument(
+        "--task-name",
+        type=str,
+        default=None,
+        help="Optional task name for multi-task models (e.g. omol, omat, odac for fairchem UMA)",
+    )
+    p.add_argument(
+        "--optimizer",
+        type=str,
+        default="LBFGS",
+        choices=["LBFGS", "FIRE"],
+        help="ASE optimizer to use",
+    )
+    p.add_argument("--fmax", type=float, default=0.05, help="Force convergence threshold (eV/Å)")
+    p.add_argument("--steps", type=int, default=500, help="Maximum optimization steps")
+    p.add_argument(
+        "--relax-cell",
+        action="store_true",
+        default=True,
+        help="Relax the unit cell (default: True)",
+    )
+    p.add_argument(
+        "--fixed-cell",
+        action="store_true",
+        default=False,
+        help="Fix the unit cell during relaxation (overrides --relax-cell)",
+    )
+    p.add_argument(
+        "--device",
+        type=str,
+        default="auto",
+        choices=["auto", "cuda", "cpu"],
+        help="Device to use ('auto' picks CUDA if available)",
+    )
+    p.add_argument("--output-dir", type=Path, default=None, help="Directory to save relaxed structure and results")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    device = select_device(args.device)
+    relax_cell = args.relax_cell and not args.fixed_cell
+
+    # Read structure
+    atoms = read(str(args.structure))
+    normalize_charge_spin(atoms)
+    print(f"Loaded structure: {args.name} ({len(atoms)} atoms) from {args.structure}")
+
+    # Load MLIP
+    print(f"Loading {args.calculator} model: {args.model_name} (task={args.task_name}, device={device})")
+    wrapper = load_wrapper(
+        args.calculator,
+        model_name=args.model_name,
+        device=device,
+        task_name=args.task_name,
+    )
+    calc = wrapper.create_calculator()
+    atoms.calc = calc
+
+    # Initial energy
+    e_init = atoms.get_potential_energy()
+    print(f"Initial energy: {e_init:.4f} eV")
+
+    # Set up optimizer — optionally relax cell
+    if relax_cell:
+        opt_atoms = FrechetCellFilter(atoms)
+    else:
+        opt_atoms = atoms
+
+    if args.optimizer == "LBFGS":
+        opt = LBFGS(opt_atoms, logfile="-")
+    else:
+        opt = FIRE(opt_atoms, logfile="-")
+
+    converged = opt.run(fmax=args.fmax, steps=args.steps)
+    e_final = atoms.get_potential_energy()
+    print(f"Final energy: {e_final:.4f} eV | Converged: {converged}")
+
+    # Save outputs
+    output_dir = args.output_dir or Path(f"./relaxed/{args.name}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    cif_path = output_dir / f"{args.name}.relaxed.cif"
+    write(str(cif_path), atoms)
+    print(f"Relaxed structure saved to: {cif_path}")
+
+    results = {
+        "name": args.name,
+        "calculator": args.calculator,
+        "model_name": args.model_name,
+        "task_name": args.task_name,
+        "n_atoms": len(atoms),
+        "energy_initial_eV": e_init,
+        "energy_final_eV": e_final,
+        "converged": bool(converged),
+        "optimizer": args.optimizer,
+        "fmax": args.fmax,
+        "steps": args.steps,
+        "relax_cell": relax_cell,
+        "relaxed_cif": str(cif_path),
+    }
+    json_path = output_dir / "relax_results.json"
+    with open(json_path, "w") as f:
+        json.dump(results, f, indent=2)
+    print(f"Results saved to: {json_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/chem-sorption-widom/SKILL.md
+++ b/.agents/skills/chem-sorption-widom/SKILL.md
@@ -59,6 +59,22 @@ python .agents/skills/chem-sorption-widom/scripts/run_widom.py \
     --temperature 298 \
     --output-dir ./results
 ```
+**Example 2: Using UMA-S-1p2 via uma-agent for CO2 adsorption at 298K**
+```bash
+# Env: uma-agent  (fairchem >= 2.18, supports uma-s-1p2.pt)
+PYTHONPATH=/path/to/AtomisticSkills mamba run -n uma-agent \
+    python .agents/skills/chem-sorption-widom/scripts/run_widom.py \
+        --structure ./results/COF-1_supercell.cif \
+        --name COF-1 \
+        --calculator fairchem \
+        --model-name /path/to/uma-s-1p2.pt \
+        --task-name omol \
+        --gas CO2 \
+        --temperature 298 \
+        --num-insertions 50000 \
+        --output-dir ./results
+```
+
 
 
 

--- a/.agents/skills/chem-sorption-widom/scripts/widom_src/widom/analyze.py
+++ b/.agents/skills/chem-sorption-widom/scripts/widom_src/widom/analyze.py
@@ -15,7 +15,9 @@ from pydantic import BaseModel
 
 from .utils import (
     bootstrap_ratio_std,
+    bootstrap_henry_stderr,
     calculate_atomic_density,
+    logsumexp,
 )
 
 
@@ -78,26 +80,30 @@ def analyze_widom_insertions(
     # Set invalid energies to a large value
     interaction_energies_valid = np.where(is_valid, interaction_energies, 1e10)  # [eV]
 
-    # Calculate ensemble averages properties
-    # units._e [J/eV], units._k [J/K], units._k / units._e # [eV/K]
-    boltzmann_factor = np.exp(-interaction_energies_valid / (temperature * units._k / units._e))
+    # Calculate ensemble average properties for Henry coefficient using log-sum-exp
+    kT_eV = temperature * units._k / units._e  # [eV]
+    beta = 1.0 / kT_eV
+    a = np.where(is_valid, -beta * interaction_energies_valid, -np.inf)
+    log_mean_w = logsumexp(a) - np.log(num_samples)
+    mean_w = np.exp(log_mean_w)
 
     # KH = <exp(-E/RT)> / (R * T)
     atomic_density = calculate_atomic_density(structure)  # [kg / m^3]
     kh = (
-        boltzmann_factor.mean()
+        mean_w
         / (units._k * units._Nav)  # R = [J / mol K] = [Pa m^3 / mol K]
         / temperature  # T = [K] -> [mol/ m^3 Pa]
         / atomic_density  #  = [kg / m^3] -> [mol / kg Pa]
     )  # [mol/kg Pa]
 
-    # Estimate std dev of estimator. Is a mean, so we take the std dev of terms/sqrt(N)
-    kh_std = (
-        boltzmann_factor.std()
-        / (units._k * units._Nav)
-        / temperature
-        / atomic_density
-        / np.sqrt(num_samples)
+    # Estimate standard deviation of Henry coefficient using bootstrap
+    kh_std = bootstrap_henry_stderr(
+        interaction_energies_valid,
+        is_valid,
+        temperature,
+        atomic_density,
+        n_bootstrap=100,
+        random_seed=random_seed,
     )  # [mol/kg Pa]
 
     # U = < E * exp(-E/RT) > / <exp(-E/RT)> # [eV]

--- a/.agents/skills/chem-sorption-widom/scripts/widom_src/widom/utils.py
+++ b/.agents/skills/chem-sorption-widom/scripts/widom_src/widom/utils.py
@@ -267,3 +267,47 @@ def calculate_atomic_density(atoms: Atoms) -> float:
     volume = atoms.get_volume() * 1e-30  # Convert Å³ to m³
     total_mass = np.sum(atoms.get_masses()) * units._amu  # Convert amu to kg # type: ignore
     return total_mass / volume
+
+
+def logsumexp(a):
+    """Compute log(sum(exp(a))) in a numerically stable way.
+
+    Entries equal to -np.inf effectively contribute zero.
+    """
+    a = np.asarray(a, dtype=float)
+    a_max = np.max(a)
+    if np.isneginf(a_max):
+        return float(-np.inf)
+    return float(a_max + np.log(np.exp(a - a_max).sum()))
+
+
+def bootstrap_henry_stderr(
+    interaction_energies_valid,
+    is_valid,
+    temperature,
+    atomic_density,
+    n_bootstrap,
+    random_seed,
+):
+    """Calculate standard deviation of Henry coefficient using bootstrap.
+
+    Uses log-sum-exp to compute the ensemble average of Boltzmann weights
+    in a numerically stable way while ignoring invalid samples.
+    """
+    kT_eV = temperature * units._k / units._e
+    beta = 1.0 / kT_eV
+    R = units._k * units._Nav
+
+    n = len(interaction_energies_valid)
+    kh_samples = np.zeros(n_bootstrap)
+
+    rng = np.random.default_rng(random_seed)
+
+    for i in range(n_bootstrap):
+        idx = rng.choice(n, size=n, replace=True)
+        a = np.where(is_valid[idx], -beta * interaction_energies_valid[idx], -np.inf)
+        log_mean_w = logsumexp(a) - np.log(n)
+        mean_w = np.exp(log_mean_w)
+        kh_samples[i] = mean_w / (R * temperature * atomic_density)
+
+    return float(np.std(kh_samples))

--- a/conda-envs/uma-agent/core_env.yaml
+++ b/conda-envs/uma-agent/core_env.yaml
@@ -1,0 +1,17 @@
+name: uma-agent
+channels:
+  - conda-forge
+  - pytorch
+  - nvidia
+dependencies:
+  - python=3.12
+  - pip
+  - pip:
+    - torch>=2.3.0
+    - fairchem-core>=2.18.0
+    - ase>=3.23
+    - numpy
+    - scipy
+    - tqdm-loggable
+    - pydantic
+    - pymatgen

--- a/conda-envs/uma-agent/install.sh
+++ b/conda-envs/uma-agent/install.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+# Get the directory of the script
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR"
+
+ENV_NAME=$(grep -e '^name:' core_env.yaml | awk '{print $2}')
+echo "Creating Conda environment $ENV_NAME without pip dependencies..."
+
+# Create a temporary yaml without the pip section
+sed '/^[[:space:]]*- pip:/,$d' core_env.yaml > conda_only_env.yaml
+
+conda env remove -n $ENV_NAME -y || true
+conda env create -f conda_only_env.yaml
+
+# Extract pip dependencies, remove quotes
+sed -n '/^[[:space:]]*- pip:/,$p' core_env.yaml | grep -v 'pip:' | sed 's/^[[:space:]]*- //' | tr -d '"' | tr -d "'" > uv_requirements.txt
+
+# Ensure uv is installed
+if ! command -v uv &> /dev/null; then
+    echo "Installing uv..."
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
+fi
+
+# Activate and use uv
+source $(conda info --base)/etc/profile.d/conda.sh
+conda activate $ENV_NAME
+
+echo "Installing pip dependencies with uv..."
+uv pip install -r uv_requirements.txt
+
+# Cleanup
+rm conda_only_env.yaml uv_requirements.txt
+echo "Environment $ENV_NAME created successfully!"
+echo ""
+echo "NOTE: This environment requires a UMA-S model checkpoint."
+echo "Download uma-s-1p2.pt from the FairChem model hub and pass"
+echo "the path via --model-name /path/to/uma-s-1p2.pt"


### PR DESCRIPTION
- conda-envs/uma-agent: new portable env for fairchem>=2.18 (uma-s-1p2 support)
- chem-sorption-relax: add standalone relax_structure.py script (fairchem/mace/matgl backends); update SKILL.md with Option B (uma-agent) 
- chem-sorption-widom: switch K_H to numerically stable log-sum-exp; replace simple std with bootstrap stderr (100 samples); add uma-agent example to SKILL.md
- chem-db-mof: new skill for querying QMOF (MPContribs) and ARC-MOF DB7 (Majumdar et al.) databases