### PR TITLE
Fix odac Widom spin handling

### DIFF
--- a/.agents/skills/chem-sorption-widom/scripts/run_widom.py
+++ b/.agents/skills/chem-sorption-widom/scripts/run_widom.py
@@ -30,7 +30,17 @@ from widom_common import (
 )
 
 
-def normalize_charge_spin(atoms) -> None:
+def normalize_charge_spin(atoms, task_name: str) -> None:
+    """Write charge/spin into atoms.info only for the omol head.
+
+    For odac/omat/omc/oc20, leave atoms.info untouched so fairchem's
+    AtomicData.from_ase falls back to spin=0 (the trained default for
+    those heads). Forcing spin=1 on non-omol systems perturbs the
+    shared-backbone csd_embedding and biases energies.
+    """
+    if task_name != "omol":
+        return
+
     info = atoms.info if isinstance(atoms.info, dict) else {}
     if atoms.info is not info:
         atoms.info = info
@@ -47,6 +57,7 @@ def normalize_charge_spin(atoms) -> None:
     atoms.info["charge"] = charge
     atoms.info["spin_multiplicity"] = spin_mult
     atoms.info["spin"] = spin_mult
+
 
 
 def parse_args() -> argparse.Namespace:

--- a/.agents/skills/chem-sorption-widom/scripts/run_widom.py
+++ b/.agents/skills/chem-sorption-widom/scripts/run_widom.py
@@ -94,7 +94,7 @@ def main() -> int:
 
     device = select_device(args.device)
     atoms = read_structure(args.structure)
-    normalize_charge_spin(atoms)
+    normalize_charge_spin(atoms, args.task_name)
 
     model_tag = args.model_tag or f"{args.calculator}_{args.model_name}"
     


### PR DESCRIPTION
## Summary

Fixes Widom insertion behavior for `odac` by avoiding unconditional charge/spin normalization for non-`omol` tasks.

The previous code copied `spin_multiplicity` into `atoms.info["spin"]` for all task heads, which forced `spin=1` for `odac` periodic systems and produced bad Widom energies.

## Changes

- Updated `normalize_charge_spin` to accept `task_name`
- Only writes charge/spin metadata for `omol`
- Leaves `odac`/periodic task heads untouched so Fairchem defaults are used

## Testing

- Confirmed the PR changes only `run_widom.py`

Fixes #30