### PR TITLE
feat/chem skills msms

### DIFF
--- a/.agents/skills/chem-msms-predict/SKILL.md
+++ b/.agents/skills/chem-msms-predict/SKILL.md
@@ -1,0 +1,137 @@
+
+---
+name: chem-msms-predict
+description: Predict LC-MS/MS (MS2, tandem mass spectra) from SMILES via ICEBERG, a two-stage deep neural network. Outputs predicted m/z vs intensity spectrum, fragment ion SMILES, and a spectrum plot.
+category: chemistry
+---
+
+# LC-MS/MS Spectrum Prediction
+
+## Goal
+
+Predict the LC-MS/MS (tandem mass) spectrum of a molecule given its SMILES string using ICEBERG — a two-stage GNN that first generates a fragmentation DAG (fragment ions) and then predicts their intensities. Output is a predicted spectrum (m/z, intensity) with optional fragment SMILES assignments per peak.
+
+## When to Use This Skill
+
+- A SMILES string is known and a predicted LC-MS/MS spectrum (m/z vs intensity) is needed.
+- Fragment ion assignments (SMILES per peak) are required.
+- No reference spectrum exists, or comparison to a predicted spectrum is desired.
+- Companion skill `chem-spectrum-matcher` can compare predicted vs experimental spectra.
+
+## When NOT to Use This Skill
+
+- **Experimental spectrum already available** — use it directly; no prediction needed.
+- **Only compound name known** — first resolve to SMILES via `drug-db-pubchem`, then call this skill.
+- **GC-MS or other MS types** — ICEBERG is trained on LC-MS/MS only; flag a warning before proceeding.
+- **Organometallics or MW > 1000** — predictions may be unreliable or fail due to unsupported element types.
+
+## Prerequisites
+
+### 1. Download ICEBERG checkpoints
+
+Download from [coleygroup/ms-pred releases](https://github.com/coleygroup/ms-pred) and place in `downloads/`:
+
+```
+downloads/
+├── iceberg_dag_gen_msg_best.ckpt    # generator (stage 1)
+└── iceberg_dag_gen_msg_last.ckpt   # intensity predictor (stage 2)
+```
+
+**Flag error and stop** if either checkpoint is missing.
+
+### 2. Set up the conda environment
+
+```bash
+bash conda-envs/msms-agent/install.sh
+```
+
+The `ms_pred` Python package is installed from GitHub automatically by the install script.
+
+## Instructions
+
+### Step 1 — Run inference and generate spectrum
+
+```bash
+# Env: ms-gen
+python .agents/skills/chem-msms-predict/scripts/predict_msms.py \
+    --smiles "c1ccccc1C(=O)OCCN" \
+    --gen_ckpt downloads/iceberg_dag_gen_msg_best.ckpt \
+    --inten_ckpt downloads/iceberg_dag_gen_msg_last.ckpt \
+    --collision_energies 20 40 \
+    --adduct "[M+H]+" \
+    --output_dir results/msms_prediction
+```
+
+**Key parameters:**
+- `--smiles` — input molecule as SMILES string
+- `--gen_ckpt` / `--inten_ckpt` — paths to ICEBERG checkpoints
+- `--collision_energies` — one or more collision energies in eV (e.g. `20 40 60`); model was trained on absolute eV values
+- `--adduct` — supported adducts: `[M+H]+`, `[M-H]-`, `[M+Na]+`, `[M+NH4]+`, and others from `ms_pred.common.ion2mass`
+- `--threshold` — confidence cutoff for DAG fragment generator (default `0.1`; lower = more fragments)
+- `--sparse_k` — maximum number of peaks returned (default `100`)
+- `--cuda_devices` — GPU device IDs (e.g. `"0"` or `"0,1"`); omit or set to `None` for CPU
+
+**Outputs written to `--output_dir`:**
+| File | Description |
+|------|-------------|
+| `spectrum.png` | Stem plot of predicted spectrum, one panel per collision energy |
+| `fragments.json` | JSON list per CE: `{mz, intensity, fragment_smiles}` sorted by intensity |
+| `input_configs.yaml` | All run parameters for reproducibility |
+
+### Step 2 — Inspect fragment assignments (optional)
+
+`fragments.json` maps each predicted peak to the fragment ion SMILES responsible for it:
+
+```json
+{
+  "20": [
+    {"mz": 122.0600, "intensity": 1.0, "fragment_smiles": "c1ccccc1C=O"},
+    ...
+  ]
+}
+```
+
+Use this to rationalize which bonds fragment at which energy.
+
+### Step 3 — Compare with experimental spectrum (optional)
+
+If an experimental spectrum is available, use the companion skill:
+
+→ [`chem-spectrum-matcher`](../chem-spectrum-matcher/SKILL.md)
+
+## Examples
+
+### 2-Aminoethyl benzoate (`c1ccccc1C(=O)OCCN`)
+
+```bash
+# Env: ms-gen
+python .agents/skills/chem-msms-predict/examples/predict_smiles.py \
+    --gen_ckpt downloads/iceberg_dag_gen_msg_best.ckpt \
+    --inten_ckpt downloads/iceberg_dag_gen_msg_last.ckpt \
+    --output_dir .agents/test/msms_example
+```
+
+Expected output:
+- `spectrum.png` — two-panel spectrum (20 eV + 40 eV)
+- `fragments.json` — fragment assignments for both energies
+- Precursor `[M+H]+` ≈ 166.087 Da
+
+## Constraints
+
+- **Environment**: All scripts require the `ms-gen` conda environment. `ms_pred` is installed automatically from GitHub by `conda-envs/msms-agent/install.sh`.
+- **Checkpoints required**: Script raises `FileNotFoundError` if `--gen_ckpt` or `--inten_ckpt` are missing.
+- **Collision energy units**: Use absolute eV values. To convert NCE → eV, set `nce=True` in `iceberg_prediction()` directly.
+- **Non-binned output only**: This skill uses `binned_out=False` (high-precision m/z). Binned output disables fragment assignment.
+- **Single-compound inference**: Provide one SMILES per call. For batch prediction, loop over SMILES and use separate output dirs.
+- **Unsupported elements**: Molecules containing metals, lanthanides, or rare main-group elements may fail or produce low-quality predictions.
+- **MW limit**: ICEBERG is unreliable for MW > 1000 Da.
+
+## References
+
+- Alberts, M. et al., "Artificial intelligence for context-aware mass spectrometry", *Nature Methods*, 2025. [DOI:10.1038/s41592-025-02658-z](https://doi.org/10.1038/s41592-025-02658-z)
+- ICEBERG source code: [github.com/coleygroup/ms-pred](https://github.com/coleygroup/ms-pred)
+
+---
+
+**Author:** Magdalena Lederbauer
+**Contact:** [magled@mit.edu](mailto:magled@mit.edu)

--- a/.agents/skills/chem-msms-predict/SKILL.md
+++ b/.agents/skills/chem-msms-predict/SKILL.md
@@ -33,8 +33,8 @@ Download from [coleygroup/ms-pred releases](https://github.com/coleygroup/ms-pre
 
 ```
 downloads/
-├── iceberg_dag_gen_msg_best.ckpt    # generator (stage 1)
-└── iceberg_dag_gen_msg_last.ckpt   # intensity predictor (stage 2)
+├── iceberg_dag_gen_msg_best.ckpt     # generator (stage 1)
+└── iceberg_dag_inten_msg_best.ckpt   # intensity predictor (stage 2)
 ```
 
 **Flag error and stop** if either checkpoint is missing.
@@ -56,7 +56,7 @@ The `ms_pred` Python package is installed from GitHub automatically by the insta
 python .agents/skills/chem-msms-predict/scripts/predict_msms.py \
     --smiles "c1ccccc1C(=O)OCCN" \
     --gen_ckpt downloads/iceberg_dag_gen_msg_best.ckpt \
-    --inten_ckpt downloads/iceberg_dag_gen_msg_last.ckpt \
+    --inten_ckpt downloads/iceberg_dag_inten_msg_best.ckpt \
     --collision_energies 20 40 \
     --adduct "[M+H]+" \
     --output_dir results/msms_prediction
@@ -107,7 +107,7 @@ If an experimental spectrum is available, use the companion skill:
 # Env: ms-gen
 python .agents/skills/chem-msms-predict/examples/predict_smiles.py \
     --gen_ckpt downloads/iceberg_dag_gen_msg_best.ckpt \
-    --inten_ckpt downloads/iceberg_dag_gen_msg_last.ckpt \
+    --inten_ckpt downloads/iceberg_dag_inten_msg_best.ckpt \
     --output_dir .agents/test/msms_example
 ```
 

--- a/.agents/skills/chem-msms-predict/SKILL.md
+++ b/.agents/skills/chem-msms-predict/SKILL.md
@@ -134,4 +134,4 @@ Expected output:
 ---
 
 **Author:** Magdalena Lederbauer
-**Contact:** [magled@mit.edu](mailto:magled@mit.edu)
+**Contact:** [GitHub @mlederbauer](https://github.com/mlederbauer)

--- a/.agents/skills/chem-msms-predict/examples/README.md
+++ b/.agents/skills/chem-msms-predict/examples/README.md
@@ -1,0 +1,51 @@
+# chem-msms-predict examples
+
+One worked example demonstrating LC-MS/MS spectrum prediction via ICEBERG for a small organic molecule.
+
+## Prerequisites
+
+- `ms-gen` conda environment activated (see `conda-envs/msms-agent/install.sh`)
+- ICEBERG checkpoints downloaded to `downloads/`:
+  - `downloads/iceberg_dag_gen_msg_best.ckpt` (stage 1: fragment DAG generator)
+  - `downloads/iceberg_dag_inten_msg_best.ckpt` (stage 2: intensity predictor)
+
+## Example: 2-Aminoethyl benzoate
+
+**Script**: `predict_smiles.py`
+**Molecule**: 2-aminoethyl benzoate — `c1ccccc1C(=O)OCCN`
+**Precursor**: `[M+H]+` ≈ 166.087 Da
+
+Runs inference at collision energies 20 eV and 40 eV and writes results to `.agents/test/msms_example/`.
+
+```bash
+# Env: ms-gen
+python .agents/skills/chem-msms-predict/examples/predict_smiles.py \
+    --gen_ckpt downloads/iceberg_dag_gen_msg_best.ckpt \
+    --inten_ckpt downloads/iceberg_dag_inten_msg_best.ckpt \
+    --output_dir .agents/test/msms_example
+```
+
+**Outputs**:
+
+| File | Description |
+|------|-------------|
+| `spectrum.png` | Two-panel stem plot (20 eV + 40 eV) |
+| `fragments.json` | Fragment SMILES per peak, sorted by intensity |
+| `input_configs.yaml` | Full run parameters for reproducibility |
+
+## Extending to other molecules
+
+Adapt `predict_smiles.py` or call the underlying script directly:
+
+```bash
+# Env: ms-gen
+python .agents/skills/chem-msms-predict/scripts/predict_msms.py \
+    --smiles "<your SMILES>" \
+    --gen_ckpt downloads/iceberg_dag_gen_msg_best.ckpt \
+    --inten_ckpt downloads/iceberg_dag_inten_msg_best.ckpt \
+    --collision_energies 20 40 60 \
+    --adduct "[M+H]+" \
+    --output_dir results/my_compound
+```
+
+See [SKILL.md](../SKILL.md) for full parameter reference and constraints.

--- a/.agents/skills/chem-msms-predict/examples/predict_smiles.py
+++ b/.agents/skills/chem-msms-predict/examples/predict_smiles.py
@@ -6,7 +6,7 @@ Run from project root:
     # Env: ms-gen
     python .agents/skills/chem-msms-predict/examples/predict_smiles.py \\
         --gen_ckpt downloads/iceberg_dag_gen_msg_best.ckpt \\
-        --inten_ckpt downloads/iceberg_dag_gen_msg_last.ckpt
+        --inten_ckpt downloads/iceberg_dag_inten_msg_best.ckpt
 """
 
 import argparse

--- a/.agents/skills/chem-msms-predict/examples/predict_smiles.py
+++ b/.agents/skills/chem-msms-predict/examples/predict_smiles.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""
+Example: predict LC-MS/MS spectrum for 2-aminoethyl benzoate (c1ccccc1C(=O)OCCN).
+
+Run from project root:
+    # Env: ms-gen
+    python .agents/skills/chem-msms-predict/examples/predict_smiles.py \\
+        --gen_ckpt downloads/iceberg_dag_gen_msg_best.ckpt \\
+        --inten_ckpt downloads/iceberg_dag_gen_msg_last.ckpt
+"""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+EXAMPLE_SMILES = "c1ccccc1C(=O)OCCN"  # 2-aminoethyl benzoate
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="ICEBERG example: 2-aminoethyl benzoate")
+    p.add_argument("--gen_ckpt", required=True, type=Path)
+    p.add_argument("--inten_ckpt", required=True, type=Path)
+    p.add_argument("--output_dir", type=Path, default=Path(".agents/test/msms_example"))
+    p.add_argument("--cuda_devices", default=None)
+    args = p.parse_args()
+
+    script = Path(__file__).parent.parent / "scripts" / "predict_msms.py"
+    cmd = [
+        sys.executable, str(script),
+        "--smiles", EXAMPLE_SMILES,
+        "--gen_ckpt", str(args.gen_ckpt),
+        "--inten_ckpt", str(args.inten_ckpt),
+        "--collision_energies", "20", "40",
+        "--adduct", "[M+H]+",
+        "--output_dir", str(args.output_dir),
+        "--num_workers", "0",
+    ]
+    if args.cuda_devices:
+        cmd += ["--cuda_devices", args.cuda_devices]
+
+    print(f"Predicting spectrum for: {EXAMPLE_SMILES}")
+    subprocess.run(cmd, check=True)
+    print(f"\nResults written to: {args.output_dir}")
+    print("  spectrum.png       — predicted MS/MS spectrum plot")
+    print("  fragments.json     — fragment SMILES per peak")
+    print("  input_configs.yaml — run parameters")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/chem-msms-predict/scripts/predict_msms.py
+++ b/.agents/skills/chem-msms-predict/scripts/predict_msms.py
@@ -9,14 +9,14 @@ Usage:
     python .agents/skills/chem-msms-predict/scripts/predict_msms.py \\
         --smiles "c1ccccc1C(=O)OCCN" \\
         --gen_ckpt downloads/iceberg_dag_gen_msg_best.ckpt \\
-        --inten_ckpt downloads/iceberg_dag_gen_msg_last.ckpt \\
+        --inten_ckpt downloads/iceberg_dag_inten_msg_best.ckpt \\
         --collision_energies 20 40 \\
         --output_dir results/msms_prediction
 
 Requirements:
     - Conda environment: ms-gen
     - Checkpoints: downloads/iceberg_dag_gen_msg_best.ckpt
-                   downloads/iceberg_dag_gen_msg_last.ckpt
+                   downloads/iceberg_dag_inten_msg_best.ckpt
 """
 
 import argparse

--- a/.agents/skills/chem-msms-predict/scripts/predict_msms.py
+++ b/.agents/skills/chem-msms-predict/scripts/predict_msms.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""
+Predict LC-MS/MS spectra from SMILES via ICEBERG (two-stage DAG + intensity GNN).
+
+Runs inference, saves fragment SMILES assignments, and plots the predicted spectrum.
+
+Usage:
+    # Env: ms-gen
+    python .agents/skills/chem-msms-predict/scripts/predict_msms.py \\
+        --smiles "c1ccccc1C(=O)OCCN" \\
+        --gen_ckpt downloads/iceberg_dag_gen_msg_best.ckpt \\
+        --inten_ckpt downloads/iceberg_dag_gen_msg_last.ckpt \\
+        --collision_energies 20 40 \\
+        --output_dir results/msms_prediction
+
+Requirements:
+    - Conda environment: ms-gen
+    - Checkpoints: downloads/iceberg_dag_gen_msg_best.ckpt
+                   downloads/iceberg_dag_gen_msg_last.ckpt
+"""
+
+import argparse
+import json
+import sys
+import yaml
+from pathlib import Path
+
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
+
+
+def run_iceberg(
+    smiles: str,
+    gen_ckpt: Path,
+    inten_ckpt: Path,
+    collision_energies: list,
+    adduct: str,
+    cuda_devices,
+    batch_size: int,
+    num_workers: int,
+    sparse_k: int,
+    max_nodes: int,
+    threshold: float,
+) -> tuple:
+    """Run ICEBERG two-stage inference. Returns (save_dir, precursor_mass)."""
+    from ms_pred.dag_pred.iceberg_elucidation import iceberg_prediction
+
+    save_dir, precursor_mass = iceberg_prediction(
+        candidate_smiles=[smiles],
+        collision_energies=collision_energies,
+        nce=False,
+        adduct=adduct,
+        exp_name="skill_pred",
+        python_path=sys.executable,
+        gen_ckpt=str(gen_ckpt),
+        inten_ckpt=str(inten_ckpt),
+        cuda_devices=cuda_devices,
+        batch_size=batch_size,
+        num_workers=num_workers,
+        sparse_k=sparse_k,
+        max_nodes=max_nodes,
+        threshold=threshold,
+        binned_out=False,
+        force_recompute=True,
+    )
+    return save_dir, precursor_mass
+
+
+def load_predictions(save_dir: Path) -> tuple:
+    """
+    Load predicted spectra and fragment SMILES from ICEBERG HDF5 output.
+
+    Returns:
+        spec_dict: {collision_energy_str -> (K,2) ndarray of [mz, intensity]}
+        frag_dict: {collision_energy_str -> list of fragment SMILES}
+        canonical_smi: SMILES as stored in HDF5
+    """
+    from ms_pred.dag_pred.iceberg_elucidation import load_pred_spec
+
+    smiles_arr, pred_specs, pred_frags = load_pred_spec(save_dir, merge_spec=False)
+    return pred_specs[0], pred_frags[0], smiles_arr[0]
+
+
+def plot_spectrum(
+    spec_dict: dict,
+    smiles: str,
+    precursor_mass: float,
+    adduct: str,
+    output_path: Path,
+) -> None:
+    """Stem plot of predicted MS/MS spectrum, one panel per collision energy."""
+    ces = sorted(spec_dict.keys(), key=lambda x: float(x))
+    n = len(ces)
+    fig, axes = plt.subplots(n, 1, figsize=(10, 3.5 * n), squeeze=False)
+
+    for ax, ce in zip(axes[:, 0], ces):
+        spec = spec_dict[ce]
+        mz = spec[:, 0]
+        inten = spec[:, 1] / spec[:, 1].max()
+
+        _, stemlines, _ = ax.stem(mz, inten, linefmt="C0-", markerfmt=" ", basefmt="k-")
+        plt.setp(stemlines, linewidth=0.8)
+
+        ax.axvline(
+            precursor_mass, color="red", linestyle="--", linewidth=0.8, alpha=0.6,
+            label=f"precursor {adduct} ({precursor_mass:.4f} Da)",
+        )
+
+        for i in np.argsort(inten)[::-1][:5]:
+            ax.text(mz[i], inten[i] + 0.02, f"{mz[i]:.2f}", fontsize=7,
+                    ha="center", va="bottom", color="C0")
+
+        try:
+            ce_label = f"{float(ce):.0f} eV"
+        except ValueError:
+            ce_label = str(ce)
+
+        ax.set_title(f"{smiles}  |  CE: {ce_label}", fontsize=9)
+        ax.set_xlabel("m/z", fontsize=9)
+        ax.set_ylabel("Relative Intensity", fontsize=9)
+        ax.set_ylim(-0.05, 1.3)
+        ax.xaxis.set_major_locator(ticker.AutoLocator())
+        ax.legend(fontsize=7, loc="upper right")
+
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Spectrum plot saved: {output_path}")
+
+
+def save_fragments(spec_dict: dict, frag_dict: dict, output_path: Path) -> None:
+    """Save {ce -> [{mz, intensity, fragment_smiles}]} sorted by intensity descending."""
+    result = {}
+    for ce in spec_dict:
+        spec = spec_dict[ce]
+        frags = frag_dict.get(ce, [])
+        max_inten = spec[:, 1].max()
+        entries = [
+            {
+                "mz": float(spec[i, 0]),
+                "intensity": float(spec[i, 1] / max_inten),
+                "fragment_smiles": frags[i] if i < len(frags) else None,
+            }
+            for i in range(len(spec))
+        ]
+        entries.sort(key=lambda x: x["intensity"], reverse=True)
+        result[ce] = entries
+    with open(output_path, "w") as f:
+        json.dump(result, f, indent=2)
+    print(f"Fragment assignments saved: {output_path}")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Predict LC-MS/MS spectra via ICEBERG")
+    p.add_argument("--smiles", required=True, help="Input SMILES string")
+    p.add_argument(
+        "--gen_ckpt", required=True, type=Path,
+        help="ICEBERG generator checkpoint (.ckpt)",
+    )
+    p.add_argument(
+        "--inten_ckpt", required=True, type=Path,
+        help="ICEBERG intensity checkpoint (.ckpt)",
+    )
+    p.add_argument(
+        "--collision_energies", nargs="+", type=int, default=[20, 40],
+        help="Collision energies in eV (default: 20 40)",
+    )
+    p.add_argument("--adduct", default="[M+H]+", help="Adduct type (default: [M+H]+)")
+    p.add_argument(
+        "--output_dir", type=Path, default=Path("results/msms_prediction"),
+        help="Output directory",
+    )
+    p.add_argument(
+        "--cuda_devices", default=None,
+        help="CUDA device IDs e.g. '0' or '0,1'. Omit for CPU.",
+    )
+    p.add_argument("--batch_size", type=int, default=8)
+    p.add_argument("--num_workers", type=int, default=0)
+    p.add_argument("--sparse_k", type=int, default=100, help="Top-K peaks to output")
+    p.add_argument("--max_nodes", type=int, default=100, help="Max fragment DAG nodes")
+    p.add_argument(
+        "--threshold", type=float, default=0.1,
+        help="Fragment generator confidence cutoff (default: 0.1)",
+    )
+    p.add_argument(
+        "--no_fragments", action="store_true",
+        help="Skip saving fragment SMILES assignments",
+    )
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    for ckpt in (args.gen_ckpt, args.inten_ckpt):
+        if not ckpt.exists():
+            raise FileNotFoundError(
+                f"Checkpoint not found: {ckpt}\n"
+                "Download from https://github.com/coleygroup/ms-pred "
+                "and place in downloads/."
+            )
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    config = vars(args)
+    config = {k: str(v) if isinstance(v, Path) else v for k, v in config.items()}
+    with open(args.output_dir / "input_configs.yaml", "w") as f:
+        yaml.dump(config, f, default_flow_style=False)
+
+    print(f"Running ICEBERG for: {args.smiles}")
+    save_dir, precursor_mass = run_iceberg(
+        smiles=args.smiles,
+        gen_ckpt=args.gen_ckpt,
+        inten_ckpt=args.inten_ckpt,
+        collision_energies=args.collision_energies,
+        adduct=args.adduct,
+        cuda_devices=args.cuda_devices,
+        batch_size=args.batch_size,
+        num_workers=args.num_workers,
+        sparse_k=args.sparse_k,
+        max_nodes=args.max_nodes,
+        threshold=args.threshold,
+    )
+    print(f"Precursor mass ({args.adduct}): {precursor_mass:.4f} Da")
+
+    spec_dict, frag_dict, canonical_smi = load_predictions(save_dir)
+
+    plot_spectrum(
+        spec_dict=spec_dict,
+        smiles=canonical_smi,
+        precursor_mass=precursor_mass,
+        adduct=args.adduct,
+        output_path=args.output_dir / "spectrum.png",
+    )
+
+    if not args.no_fragments:
+        save_fragments(
+            spec_dict=spec_dict,
+            frag_dict=frag_dict,
+            output_path=args.output_dir / "fragments.json",
+        )
+
+    print(f"\nDone. Results in: {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/chem-spectrum-matcher/SKILL.md
+++ b/.agents/skills/chem-spectrum-matcher/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: chem-spectrum-matcher
+description: Match an experimental spectrum (1H NMR, 13C NMR, IR) against predicted or database reference spectra for candidate ranking and structure confirmation. Supports local catalog lookup, public database fallback, and pluggable similarity metrics.
+category: chemistry
+---
+
+# Spectrum Matcher
+
+## Goal
+To retrieve or generate reference spectra for a set of candidate molecules and rank them by similarity to an experimental query spectrum. The skill abstracts a common three-component pattern:
+
+1. **Prediction** — generate reference spectra from structure (SMILES) via empirical predictors or QM.
+2. **Reference DB** — cache computed spectra locally; fall back to public databases for known compounds.
+3. **Similarity metric** — score each candidate against the query and rank.
+
+This pattern applies to any spectral modality: 1H NMR, 13C NMR, IR, mass spectrometry, UV-Vis, Raman. The concrete implementation here covers **1H NMR** and **IR**, with the NMR path fully implemented and IR sketched for extension.
+
+## When to Use This Skill
+
+- Confirm a proposed structure against an experimental spectrum.
+- Screen a shortlist of candidates and rank by spectral similarity.
+- Avoid re-running expensive predictions by retrieving cached spectra from the local catalog.
+- Fetch experimental reference spectra from public databases (NMRShiftDB2, NIST WebBook) before committing to a prediction run.
+
+## When NOT to Use This Skill
+
+- **Unknown structure elucidation from scratch** — this skill requires a candidate list. For open-ended structure identification, use `general-query-literature-database` first.
+- **Mixture deconvolution** — use `chem-nmr-analysis` (Wasserstein deconvolution) for quantifying component ratios.
+- **13C, 19F, 31P NMR prediction** — `chem-nmr-predict` (SPINUS) covers 1H only. Extension needed.
+- **Mass spectrometry** — not yet implemented. Scaffold is in place; add a predictor and similarity metric.
+
+---
+
+## Architecture
+
+```
+SMILES  ──► [Predictor]  ──► predicted spectrum (.xy / .jdx)
+                                        │
+                                        ▼
+                              [Local Catalog]  ◄──  register_spectrum.py
+                                        │
+        [Public DB fallback]  ──────────┤  (NMRShiftDB2, NIST WebBook)
+                                        │
+                                        ▼
+            Experimental query  ──► [match_spectrum.py]  ──► ranked candidates
+```
+
+### Modality–Predictor–Metric table
+
+| Modality | Predictor skill | Public DB | Similarity metric |
+|---|---|---|---|
+| 1H NMR | `chem-nmr-predict` (SPINUS + nmrsim) | NMRShiftDB2 | L2 / Wasserstein |
+| IR | `chem-db-spectra` (NIST) or ORCA DFT | NIST WebBook | Cosine |
+| 13C NMR | *(not yet implemented)* | NMRShiftDB2 | L2 |
+| Mass spec | *(not yet implemented)* | NIST WebBook | Dot product |
+
+---
+
+## Workflow
+
+### Step 1 — Prepare Candidate Reference Spectra
+
+#### Option A: Retrieve from catalog or public DB (fast, no prediction)
+
+```bash
+# Env: nmr-agent
+python .agents/skills/chem-spectrum-matcher/scripts/match_spectrum.py \
+  --query experimental_spectrum.xy \
+  --smiles "CCO" \
+  --names "ethanol" \
+  --modality nmr_1h \
+  --catalog_dir research/spectrum_catalog/ \
+  --output_dir <research_dir>/spectrum_match/ \
+  --fallback_public_db
+```
+
+#### Option B: Predict first, then match
+
+Run the appropriate predictor for the modality, then register outputs into the catalog, then match.
+
+**1H NMR:**
+```bash
+# Env: nmr-agent
+python .agents/skills/chem-nmr-predict/scripts/predict_nmr.py \
+  --smiles "CCO" \
+  --names "ethanol" \
+  --field_mhz 400 \
+  --output_dir <research_dir>/nmr_predictions/
+
+# Env: nmr-agent
+python .agents/skills/chem-spectrum-matcher/scripts/register_spectrum.py \
+  --source_dir <research_dir>/nmr_predictions/ \
+  --modality nmr_1h \
+  --catalog_dir research/spectrum_catalog/
+```
+
+**IR (from NIST WebBook):**
+```bash
+# Env: base-agent
+python .agents/skills/chem-db-spectra/scripts/query_spectra.py \
+  C10H18O <research_dir>/ir_references/ --type IR
+
+# Env: base-agent
+python .agents/skills/chem-spectrum-matcher/scripts/register_spectrum.py \
+  --source_dir <research_dir>/ir_references/ \
+  --modality ir \
+  --catalog_dir research/spectrum_catalog/
+```
+
+**IR (QM-backed, high accuracy):**
+```bash
+# Env: orca-agent
+# Run ORCA frequency calculation → extract IR spectrum → register
+# See conda-envs/orca-agent/ for ORCA setup.
+# After ORCA run, convert output with src/utils/dft/orca_utils.py
+# then call register_spectrum.py --modality ir
+```
+
+### Step 2 — Match and Rank
+
+`match_spectrum.py` retrieves reference spectra (catalog → public DB fallback) and computes similarity scores between the query and each candidate.
+
+```bash
+# Env: nmr-agent
+python .agents/skills/chem-spectrum-matcher/scripts/match_spectrum.py \
+  --query experimental_spectrum.xy \
+  --smiles "CCO" \
+  --names "ethanol" \
+  --modality nmr_1h \
+  --metric l2 \
+  --catalog_dir research/spectrum_catalog/ \
+  --output_dir <research_dir>/spectrum_match/ \
+  --plot
+```
+
+**Arguments:**
+- `--query`: experimental spectrum file (two-column, ppm/wavenumber vs intensity; `.xy`, `.csv`, `.jdx`).
+- `--smiles`: candidate SMILES strings.
+- `--names`: human-readable labels matching SMILES order.
+- `--modality`: `nmr_1h`, `nmr_13c`, `ir`. Controls which catalog partition and public DB to query.
+- `--metric`: similarity metric — `l2` (default), `cosine`, `wasserstein`. Choose based on modality (see table above).
+- `--catalog_dir`: local spectrum catalog directory.
+- `--fallback_public_db`: query NMRShiftDB2 or NIST WebBook for any candidate not in catalog.
+- `--field_mhz`: spectrometer field (NMR only, default 400). Must match experimental spectrum.
+- `--plot`: emit overlay plot (`match_plot.png`) with query and top-3 candidates.
+- `--output_dir`: directory for outputs.
+
+**Outputs:**
+- `match_results.json` — ranked candidates with similarity scores, source (catalog/public_db/predicted), and spectrum paths.
+- `match_plot.png` — overlay of query vs ranked references (if `--plot`).
+- `input_configs.yaml` — all parameters for reproducibility.
+
+### Step 3 — Interpret Results
+
+Read `match_results.json`. Candidates are ranked by descending similarity score (1.0 = perfect match, 0.0 = no overlap).
+
+**If/Then rules:**
+
+| Score (L2 / cosine) | Interpretation | Agent action |
+|---|---|---|
+| > 0.90 | Strong match | Report top candidate with confidence. |
+| 0.70–0.90 | Plausible match | Report with caveat; check overlay plot for unmatched peaks. |
+| < 0.70 | Poor match | Likely wrong candidate or missing structure. Expand candidate list or re-examine experimental spectrum. |
+
+After reading scores, the agent must:
+1. **Inspect `match_plot.png`** — verify visual agreement, check for systematic shifts.
+2. **Cross-check with signal table** (NMR) — compare predicted multiplicity/coupling to experimental assignments.
+3. **If top candidate has score < 0.70** — consider running QM-backed prediction (ORCA IR, or higher-level NMR) rather than empirical.
+
+---
+
+## Failure Modes
+
+| Failure | Symptom | Agent action |
+|---|---|---|
+| Catalog miss, no public DB hit | `match_results.json` candidate marked `missed` | Run appropriate predictor then `register_spectrum.py`. |
+| Ppm/wavenumber axis mismatch | Similarity scores all near 0 | Query and reference use different x-axis. Check `--field_mhz` or unit convention. |
+| SMILES canonicalization fails | RDKit error | SMILES invalid. Verify with RDKit before retry. |
+| NMRShiftDB2 / NIST timeout | HTTP error during public DB query | Retry once; if persistent, disable `--fallback_public_db` and predict locally. |
+| ORCA IR prediction unavailable | `ORCA_BINARY_PATH` not set | Set env var per `conda-envs/orca-agent/README.md` or fall back to NIST WebBook IR. |
+
+---
+
+## Relationship to Other Skills
+
+```
+drug-db-pubchem          → resolve compound name to SMILES
+chem-nmr-predict         → 1H NMR prediction (SPINUS + nmrsim)
+chem-db-spectra          → experimental IR/MS from NIST WebBook
+chem-nmr-analysis        → mixture deconvolution (Wasserstein)
+chem-spectrum-matcher    → this skill: catalog + retrieval + similarity ranking
+```
+
+---
+
+## Environment
+
+**Primary (NMR matching):**
+```bash
+mamba activate nmr-agent
+```
+Required packages: `numpy`, `scipy`, `rdkit`, `requests`, `matplotlib`.
+
+**IR prediction via QM (optional):**
+```bash
+mamba activate orca-agent
+```
+Requires `ORCA_BINARY_PATH` environment variable. See `conda-envs/orca-agent/README.md`.
+
+---
+
+## Constraints
+- **Catalog format**: `catalog.json` keyed by `(canonical_smiles, modality)`. Do not edit manually.
+- **Spectrum format**: `.xy` files are two-column tab-separated (x-axis descending, intensity). `.jdx` files are parsed via the `jcamp` package.
+- **Modality isolation**: NMR and IR spectra are stored in separate catalog partitions; cross-modality lookup is not supported.
+- **Field strength**: NMR catalog entries store the field (MHz) used during prediction. Retrieval warns if query field differs.
+- **Stereochemistry**: Diastereomers stored separately by canonical SMILES. Enantiomers produce identical achiral NMR/IR spectra but are stored separately for traceability.
+
+---
+
+## References
+- Steinbeck, C. et al., "NMRShiftDB — constructing a free chemical information system with open-source components", *J. Chem. Inf. Comput. Sci.*, 2003. [DOI](https://doi.org/10.1021/ci0341363)
+- Linstrom, P.J. and Mallard, W.G., Eds., *NIST Chemistry WebBook*, NIST Standard Reference Database 69. [URL](https://webbook.nist.gov)
+- Banfi, D. & Patiny, L., "www.nmrdb.org: Resurrecting and processing NMR spectra on-line", *Chimia*, 2008.
+- Landrum, G. et al., RDKit: Open-Source Cheminformatics. [URL](https://www.rdkit.org)
+
+---
+
+**Author:** Magdalena Lederbauer
+**Contact:** [GitHub @mlederbauer](https://github.com/mlederbauer)

--- a/.agents/skills/chem-spectrum-matcher/examples/nmr-ethanol/README.md
+++ b/.agents/skills/chem-spectrum-matcher/examples/nmr-ethanol/README.md
@@ -1,0 +1,114 @@
+# Example: 1H NMR Matching — Ethanol
+
+This example demonstrates the full predict → register → match cycle for ethanol (CCO, $C_2H_6O$). Ethanol has two distinct 1H signals: CH₃ triplet (~1.17 ppm) and CH₂ quartet (~3.69 ppm), making it a clean minimal test case.
+
+The same workflow applies to IR: replace `--modality nmr_1h` with `--modality ir` and supply IR `.jdx` files from `chem-db-spectra`.
+
+---
+
+## Step 1 — Predict 1H NMR Reference Spectrum
+
+```bash
+# Env: nmr-agent
+python .agents/skills/chem-nmr-predict/scripts/predict_nmr.py \
+  --smiles "CCO" \
+  --names "ethanol" \
+  --field_mhz 400 \
+  --output_dir research/nmr_predictions/
+```
+
+Outputs in `research/nmr_predictions/`:
+- `ethanol.xy`, `ethanol_signals.csv`
+- `predictions.json`
+
+## Step 2 — Register into Local Catalog
+
+```bash
+# Env: nmr-agent
+python .agents/skills/chem-spectrum-matcher/scripts/register_spectrum.py \
+  --source_dir research/nmr_predictions/ \
+  --modality nmr_1h \
+  --catalog_dir research/spectrum_catalog/
+```
+
+Expected output:
+```
+  Registered ethanol (CCO) [nmr_1h]
+Done: 1 registered, 0 skipped.
+```
+
+## Step 3 — Match an Experimental Spectrum
+
+Replace `<query>.xy` with a real two-column spectrum file (ppm vs intensity). For a self-consistency test, use the predicted spectrum itself — expect score ≈ 1.0.
+
+```bash
+# Env: nmr-agent
+python .agents/skills/chem-spectrum-matcher/scripts/match_spectrum.py \
+  --query <query>.xy \
+  --smiles "CCO" \
+  --names "ethanol" \
+  --modality nmr_1h \
+  --metric l2 \
+  --catalog_dir research/spectrum_catalog/ \
+  --output_dir research/spectrum_match/ \
+  --plot
+```
+
+### Expected `match_results.json`
+
+```json
+{
+  "query": "experimental.xy",
+  "modality": "nmr_1h",
+  "metric": "l2",
+  "candidates": [
+    {
+      "name": "ethanol",
+      "smiles": "CCO",
+      "canonical_smiles": "CCO",
+      "score": 0.951,
+      "source": "local_catalog",
+      "spectrum_path": "research/spectrum_match/ethanol_ref.xy"
+    }
+  ]
+}
+```
+
+Score > 0.90 → strong match. Agent reports ethanol as the identified compound.
+
+---
+
+## Literature Validation
+
+**Ethanol 1H NMR** (400 MHz, CDCl₃): δ 3.69 (2H, q, J = 7.0 Hz, CH₂), 2.61 (1H, s, OH), 1.17 (3H, t, J = 7.0 Hz, CH₃).
+
+SPINUS correctly predicts the CH₂/CH₃ chemical shift separation and the triplet/quartet splitting pattern.
+
+---
+
+## Extending to IR
+
+To match against IR instead of NMR, fetch references from NIST WebBook and register them:
+
+```bash
+# Env: base-agent
+python .agents/skills/chem-db-spectra/scripts/query_spectra.py C2H6O research/ir_refs/ --type IR
+
+# Env: nmr-agent  (or base-agent)
+python .agents/skills/chem-spectrum-matcher/scripts/register_spectrum.py \
+  --source_dir research/ir_refs/ \
+  --modality ir \
+  --smiles "CCO" \
+  --names "ethanol" \
+  --catalog_dir research/spectrum_catalog/
+
+python .agents/skills/chem-spectrum-matcher/scripts/match_spectrum.py \
+  --query experimental_ir.jdx \
+  --smiles "CCO" \
+  --names "ethanol" \
+  --modality ir \
+  --metric cosine \
+  --catalog_dir research/spectrum_catalog/ \
+  --output_dir research/ir_match/ \
+  --plot
+```

--- a/.agents/skills/chem-spectrum-matcher/scripts/match_spectrum.py
+++ b/.agents/skills/chem-spectrum-matcher/scripts/match_spectrum.py
@@ -1,0 +1,559 @@
+#!/usr/bin/env python3
+"""
+Match an experimental query spectrum against predicted or database reference spectra.
+
+For each candidate SMILES:
+  1. Look up local catalog (catalog.json).
+  2. Optionally fall back to NMRShiftDB2 (nmr_1h) or NIST WebBook (ir).
+  3. Compute similarity between query and each reference.
+  4. Output ranked match_results.json and optional overlay plot.
+
+Supported modalities: nmr_1h, ir
+Supported metrics:    l2, cosine, wasserstein
+
+Usage:
+    # Env: nmr-agent
+    python match_spectrum.py \\
+        --query experimental.xy \\
+        --smiles "OC1CC2CCC1C2" "OC1CC2CCC1[C@@H]2C" \\
+        --names "borneol" "isoborneol" \\
+        --modality nmr_1h \\
+        --catalog_dir research/spectrum_catalog/ \\
+        --output_dir results/spectrum_match/ \\
+        --fallback_public_db \\
+        --plot
+
+Requirements:
+    - Conda environment: nmr-agent
+    - Required packages: numpy, scipy, rdkit, requests, matplotlib
+"""
+
+import argparse
+import json
+import pathlib
+import re
+import shutil
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
+
+try:
+    from src.utils.config_utils import save_skill_inputs as _save_skill_inputs
+except ImportError:
+    _save_skill_inputs = None
+
+import numpy as np
+import requests
+
+
+SUPPORTED_MODALITIES = ("nmr_1h", "ir")
+SUPPORTED_METRICS = ("l2", "cosine", "wasserstein")
+SUPPORTED_LOOKUP = ("canonical_smiles", "inchikey", "inchikey14")
+
+# ---------------------------------------------------------------------------
+# Molecule identifier helpers
+# ---------------------------------------------------------------------------
+
+
+def mol_identifiers(smiles: str) -> dict:
+    """
+    Compute canonical SMILES, InChIKey, and InChIKey-14 from a SMILES string.
+
+    InChIKey-14 uses only the first 14 characters (connectivity layer), making
+    it insensitive to stereochemistry — enantiomers and diastereomers match the
+    same InChIKey-14 entry.
+
+    Returns dict with keys: canonical_smiles, inchikey, inchikey14.
+    Raises ValueError if SMILES is invalid.
+    """
+    from rdkit import Chem
+    from rdkit.Chem.inchi import MolToInchiKey, MolToInchi
+
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        raise ValueError(f"Invalid SMILES: {smiles}")
+    canonical = Chem.MolToSmiles(mol)
+    inchi = MolToInchi(mol) or ""
+    inchikey = MolToInchiKey(mol) or ""
+    inchikey14 = inchikey[:14] if inchikey else ""
+    return {
+        "canonical_smiles": canonical,
+        "inchikey": inchikey,
+        "inchikey14": inchikey14,
+    }
+
+
+def canonicalize(smiles: str) -> str:
+    """Return RDKit canonical SMILES, raise ValueError if invalid."""
+    from rdkit import Chem
+
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        raise ValueError(f"Invalid SMILES: {smiles}")
+    return Chem.MolToSmiles(mol)
+
+
+# ---------------------------------------------------------------------------
+# Spectrum I/O
+# ---------------------------------------------------------------------------
+
+
+def load_spectrum(path: pathlib.Path) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Load a two-column spectrum file (.xy, .csv, .tsv) or JCAMP-DX (.jdx).
+
+    Returns (x_axis, intensity) arrays sorted by ascending x_axis.
+    """
+    suffix = path.suffix.lower()
+
+    if suffix == ".jdx":
+        return _load_jdx(path)
+
+    # Auto-detect delimiter
+    text = path.read_text()
+    delimiter = "," if "," in text.split("\n")[0] else None
+    data = np.loadtxt(path, delimiter=delimiter)
+    x, y = data[:, 0], data[:, 1]
+    order = np.argsort(x)
+    return x[order], y[order]
+
+
+def _load_jdx(path: pathlib.Path) -> tuple[np.ndarray, np.ndarray]:
+    """Parse minimal JCAMP-DX file to extract x/y arrays."""
+    try:
+        import jcamp
+        data = jcamp.jcamp_readfile(str(path))
+        x = np.array(data.get("x", []))
+        y = np.array(data.get("y", []))
+    except ImportError:
+        # Fallback: parse ##XYDATA= (X++(Y..Y)) blocks manually
+        x, y = [], []
+        lines = path.read_text().splitlines()
+        in_data = False
+        x_factor = y_factor = 1.0
+        for line in lines:
+            if line.startswith("##XFACTOR="):
+                x_factor = float(line.split("=")[1])
+            if line.startswith("##YFACTOR="):
+                y_factor = float(line.split("=")[1])
+            if line.startswith("##XYDATA="):
+                in_data = True
+                continue
+            if in_data:
+                if line.startswith("##"):
+                    break
+                tokens = line.split()
+                if tokens:
+                    x.append(float(tokens[0]) * x_factor)
+                    for t in tokens[1:]:
+                        y.append(float(t) * y_factor)
+        x, y = np.array(x), np.array(y[:len(x)])
+    order = np.argsort(x)
+    return x[order], y[order]
+
+
+def interpolate_to_grid(
+    x: np.ndarray, y: np.ndarray, x_min: float, x_max: float, n_points: int = 8192
+) -> tuple[np.ndarray, np.ndarray]:
+    """Interpolate spectrum onto a uniform grid for comparison."""
+    grid = np.linspace(x_min, x_max, n_points)
+    y_grid = np.interp(grid, x, y, left=0.0, right=0.0)
+    return grid, y_grid
+
+
+def normalize(y: np.ndarray) -> np.ndarray:
+    """Min-max normalize to [0, 1]. Returns zeros if flat."""
+    y = y - y.min()
+    m = y.max()
+    return y / m if m > 0 else y
+
+
+# ---------------------------------------------------------------------------
+# Similarity metrics
+# ---------------------------------------------------------------------------
+
+
+def similarity_l2(y1: np.ndarray, y2: np.ndarray) -> float:
+    """1 - normalized L2 distance. Range [0, 1], higher = more similar."""
+    dist = np.sqrt(np.mean((y1 - y2) ** 2))
+    return float(max(0.0, 1.0 - dist))
+
+
+def similarity_cosine(y1: np.ndarray, y2: np.ndarray) -> float:
+    """Cosine similarity. Range [0, 1]."""
+    n1, n2 = np.linalg.norm(y1), np.linalg.norm(y2)
+    if n1 == 0 or n2 == 0:
+        return 0.0
+    return float(np.clip(np.dot(y1, y2) / (n1 * n2), 0.0, 1.0))
+
+
+def similarity_wasserstein(y1: np.ndarray, y2: np.ndarray) -> float:
+    """
+    1 - normalized Wasserstein-1 distance between two normalized distributions.
+
+    Treats spectra as probability distributions. Range [0, 1].
+    """
+    from scipy.stats import wasserstein_distance
+
+    # Normalize to probability distributions
+    s1, s2 = y1.sum(), y2.sum()
+    if s1 == 0 or s2 == 0:
+        return 0.0
+    dist = wasserstein_distance(np.arange(len(y1)), np.arange(len(y2)), y1 / s1, y2 / s2)
+    # Normalize by max possible distance (full width)
+    max_dist = len(y1)
+    return float(max(0.0, 1.0 - dist / max_dist))
+
+
+METRIC_FNS = {
+    "l2": similarity_l2,
+    "cosine": similarity_cosine,
+    "wasserstein": similarity_wasserstein,
+}
+
+
+# ---------------------------------------------------------------------------
+# Catalog helpers
+# ---------------------------------------------------------------------------
+
+
+def catalog_key(canonical_smiles: str, modality: str) -> str:
+    return f"{canonical_smiles}|{modality}"
+
+
+def load_catalog(catalog_dir: pathlib.Path) -> tuple[dict, dict, dict]:
+    """
+    Load catalog.json and build secondary indexes for inchikey and inchikey14.
+
+    Returns (catalog, inchikey_index, inchikey14_index).
+    - catalog: primary dict keyed by "canonical_smiles|modality"
+    - inchikey_index: maps "inchikey|modality" → primary key (exact stereo match)
+    - inchikey14_index: maps "inchikey14|modality" → list of primary keys (stereo-insensitive)
+    """
+    catalog_file = catalog_dir / "catalog.json"
+    catalog = json.loads(catalog_file.read_text()) if catalog_file.exists() else {}
+
+    inchikey_idx: dict[str, str] = {}
+    inchikey14_idx: dict[str, list[str]] = {}
+
+    for primary_key, entry in catalog.items():
+        modality = entry.get("modality", primary_key.split("|")[-1])
+        ik = entry.get("inchikey", "")
+        ik14 = entry.get("inchikey14", "")
+        if ik:
+            inchikey_idx[f"{ik}|{modality}"] = primary_key
+        if ik14:
+            k14 = f"{ik14}|{modality}"
+            inchikey14_idx.setdefault(k14, []).append(primary_key)
+
+    return catalog, inchikey_idx, inchikey14_idx
+
+
+def lookup_local(
+    ids: dict,
+    modality: str,
+    catalog: dict,
+    inchikey_idx: dict,
+    inchikey14_idx: dict,
+    output_dir: pathlib.Path,
+    safe_name: str,
+    lookup_by: str = "canonical_smiles",
+) -> pathlib.Path | None:
+    """
+    Copy cached spectrum to output_dir. Return path or None on miss.
+
+    lookup_by controls which identifier is used:
+    - "canonical_smiles": exact SMILES match (stereochemistry-aware, default)
+    - "inchikey": exact InChIKey match (stereochemistry-aware)
+    - "inchikey14": first-14-char InChIKey match (stereochemistry-insensitive;
+      returns first catalog hit when multiple stereoisomers exist)
+    """
+    if lookup_by == "canonical_smiles":
+        primary_key = catalog_key(ids["canonical_smiles"], modality)
+        entry = catalog.get(primary_key)
+    elif lookup_by == "inchikey":
+        primary_key = inchikey_idx.get(f"{ids['inchikey']}|{modality}")
+        entry = catalog.get(primary_key) if primary_key else None
+    elif lookup_by == "inchikey14":
+        candidates = inchikey14_idx.get(f"{ids['inchikey14']}|{modality}", [])
+        entry = catalog.get(candidates[0]) if candidates else None
+    else:
+        entry = None
+
+    if entry is None:
+        return None
+
+    src = pathlib.Path(entry.get("spectrum", ""))
+    if not src.exists():
+        return None
+
+    dest = output_dir / f"{safe_name}_ref{src.suffix}"
+    shutil.copy(src, dest)
+    return dest
+
+
+# ---------------------------------------------------------------------------
+# Public DB fallback
+# ---------------------------------------------------------------------------
+
+_NMRSHIFTDB2_URL = "https://nmrshiftdb.nmr.uni-koeln.de/portal/nmrshiftdb/search/searchbystructure.json"
+
+
+def fetch_nmrshiftdb2(smiles: str) -> list[tuple[float, float]]:
+    """Return (shift_ppm, intensity=1.0) peak list from NMRShiftDB2, or []."""
+    params = {"smiles": smiles, "spectrum_type": "1H", "searchtype": "substructure"}
+    try:
+        resp = requests.get(_NMRSHIFTDB2_URL, params=params, timeout=20)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception:
+        return []
+
+    spectra = data.get("spectra", []) or []
+    if not spectra:
+        return []
+
+    peaks = []
+    for token in (spectra[0].get("peakList", "") or "").split():
+        try:
+            peaks.append((float(token), 1.0))
+        except ValueError:
+            continue
+    return peaks
+
+
+def fetch_nist_ir(smiles: str) -> list[tuple[float, float]]:
+    """Placeholder: NIST IR retrieval requires formula-based lookup via chem-db-spectra."""
+    # Full implementation delegates to chem-db-spectra/scripts/query_spectra.py
+    return []
+
+
+def peaks_to_xy(
+    peaks: list[tuple[float, float]],
+    x_min: float,
+    x_max: float,
+    n_points: int = 8192,
+    linewidth: float = 1.0,
+    field_mhz: float = 400.0,
+    modality: str = "nmr_1h",
+) -> tuple[np.ndarray, np.ndarray]:
+    """Broaden a stick spectrum (peak list) to a continuous curve via Lorentzian."""
+    x_grid = np.linspace(x_min, x_max, n_points)
+    y = np.zeros(n_points)
+    hwhm = linewidth / 2.0
+
+    for pos, amp in peaks:
+        if modality == "nmr_1h":
+            freq = pos * field_mhz
+            freq_axis = x_grid * field_mhz
+        else:
+            freq, freq_axis = pos, x_grid
+
+        y += amp * (hwhm**2) / ((freq_axis - freq) ** 2 + hwhm**2)
+
+    m = y.max()
+    return x_grid, y / m if m > 0 else y
+
+
+def fetch_public_db(smiles: str, modality: str) -> list[tuple[float, float]]:
+    if modality == "nmr_1h":
+        return fetch_nmrshiftdb2(smiles)
+    elif modality == "ir":
+        return fetch_nist_ir(smiles)
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Plotting
+# ---------------------------------------------------------------------------
+
+
+def plot_overlay(
+    query_x: np.ndarray,
+    query_y: np.ndarray,
+    references: list[dict],
+    output_path: pathlib.Path,
+    modality: str,
+) -> None:
+    """Plot query vs top-3 references, stacked vertically."""
+    import matplotlib.pyplot as plt
+
+    x_label = "Chemical shift (ppm)" if "nmr" in modality else "Wavenumber (cm⁻¹)"
+    top = references[:3]
+    n = 1 + len(top)
+
+    fig, axes = plt.subplots(n, 1, figsize=(10, 2.5 * n), sharex=True)
+    if n == 1:
+        axes = [axes]
+
+    axes[0].plot(query_x, query_y, color="black", lw=1.2)
+    axes[0].set_ylabel("Query", fontsize=9)
+    axes[0].set_yticks([])
+
+    if "nmr" in modality:
+        axes[0].invert_xaxis()
+
+    for ax, ref in zip(axes[1:], top):
+        ref_path = pathlib.Path(ref["spectrum_path"])
+        if ref_path.exists():
+            rx, ry = load_spectrum(ref_path)
+            ax.plot(rx, ry, color="steelblue", lw=1.0)
+        score_str = f"{ref['score']:.3f}"
+        ax.set_ylabel(f"{ref['name']}\n({score_str})", fontsize=8)
+        ax.set_yticks([])
+
+    axes[-1].set_xlabel(x_label, fontsize=9)
+    fig.suptitle("Spectral Match: Query vs References", fontsize=10)
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Plot saved -> {output_path}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Match an experimental spectrum against predicted/database references."
+    )
+    ap.add_argument("--query", required=True, help="Experimental spectrum file (.xy, .csv, .jdx)")
+    ap.add_argument("--smiles", nargs="+", required=True, help="Candidate SMILES strings")
+    ap.add_argument("--names", nargs="+", help="Labels for candidates (order matches --smiles)")
+    ap.add_argument(
+        "--modality",
+        choices=SUPPORTED_MODALITIES,
+        default="nmr_1h",
+        help="Spectrum modality (default: nmr_1h)",
+    )
+    ap.add_argument(
+        "--metric",
+        choices=SUPPORTED_METRICS,
+        default="l2",
+        help="Similarity metric (default: l2)",
+    )
+    ap.add_argument("--catalog_dir", default="research/spectrum_catalog", help="Local catalog directory")
+    ap.add_argument("--output_dir", default="spectrum_match", help="Output directory")
+    ap.add_argument("--fallback_public_db", action="store_true", help="Query public DB on catalog miss")
+    ap.add_argument("--field_mhz", type=float, default=400.0, help="NMR field strength in MHz (default: 400)")
+    ap.add_argument("--linewidth", type=float, default=1.0, help="Lorentzian linewidth Hz for broadening (default: 1.0)")
+    ap.add_argument("--plot", action="store_true", help="Save overlay plot match_plot.png")
+    ap.add_argument(
+        "--lookup_by",
+        choices=SUPPORTED_LOOKUP,
+        default="canonical_smiles",
+        help=(
+            "Identifier used for catalog lookup: "
+            "'canonical_smiles' (exact stereo, default), "
+            "'inchikey' (exact stereo via InChIKey), "
+            "'inchikey14' (stereo-insensitive, first 14 chars of InChIKey)"
+        ),
+    )
+    args = ap.parse_args()
+
+    names = (
+        args.names
+        if args.names and len(args.names) == len(args.smiles)
+        else [f"comp{i}" for i in range(len(args.smiles))]
+    )
+
+    output_dir = pathlib.Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    catalog_dir = pathlib.Path(args.catalog_dir)
+    catalog_dir.mkdir(parents=True, exist_ok=True)
+
+    catalog, inchikey_idx, inchikey14_idx = load_catalog(catalog_dir)
+    metric_fn = METRIC_FNS[args.metric]
+
+    # Load and normalize query
+    query_path = pathlib.Path(args.query)
+    q_x, q_y = load_spectrum(query_path)
+    x_min, x_max = float(q_x.min()), float(q_x.max())
+    _, q_interp = interpolate_to_grid(q_x, q_y, x_min, x_max)
+    q_norm = normalize(q_interp)
+
+    results = []
+
+    for smiles, name in zip(args.smiles, names):
+        safe_name = re.sub(r"[^\w\-]", "_", name)[:40]
+        print(f"  {name}...", end="  ", flush=True)
+
+        try:
+            ids = mol_identifiers(smiles)
+        except ValueError as e:
+            print(f"INVALID SMILES: {e}")
+            results.append({"name": name, "smiles": smiles, "score": None, "source": "error", "error": str(e)})
+            continue
+
+        # 1. Local catalog
+        ref_path = lookup_local(
+            ids, args.modality, catalog, inchikey_idx, inchikey14_idx,
+            output_dir, safe_name, lookup_by=args.lookup_by,
+        )
+        source = "local_catalog"
+
+        # 2. Public DB fallback
+        if ref_path is None and args.fallback_public_db:
+            peaks = fetch_public_db(ids["canonical_smiles"], args.modality)
+            if peaks:
+                r_x, r_y = peaks_to_xy(
+                    peaks, x_min, x_max,
+                    linewidth=args.linewidth,
+                    field_mhz=args.field_mhz,
+                    modality=args.modality,
+                )
+                ref_path = output_dir / f"{safe_name}_ref.xy"
+                arr = np.column_stack([r_x[::-1], r_y[::-1]])
+                np.savetxt(ref_path, arr, delimiter="\t", fmt="%.6f")
+                source = "public_db"
+
+        if ref_path is None:
+            print("missed")
+            results.append({"name": name, "smiles": smiles, "score": None, "source": "missed"})
+            continue
+
+        # Compute similarity
+        r_x, r_y = load_spectrum(ref_path)
+        _, r_interp = interpolate_to_grid(r_x, r_y, x_min, x_max)
+        r_norm = normalize(r_interp)
+
+        score = metric_fn(q_norm, r_norm)
+        print(f"score={score:.3f} ({source})")
+
+        results.append({
+            "name": name,
+            "smiles": smiles,
+            "canonical_smiles": ids["canonical_smiles"],
+            "inchikey": ids["inchikey"],
+            "inchikey14": ids["inchikey14"],
+            "score": round(score, 4),
+            "source": source,
+            "spectrum_path": str(ref_path),
+        })
+
+    # Rank by score (missed entries last)
+    results.sort(key=lambda r: r.get("score") or -1.0, reverse=True)
+
+    summary = {
+        "query": str(query_path),
+        "modality": args.modality,
+        "metric": args.metric,
+        "lookup_by": args.lookup_by,
+        "candidates": results,
+    }
+    (output_dir / "match_results.json").write_text(json.dumps(summary, indent=2))
+    print(f"\nResults -> {output_dir}/match_results.json")
+
+    if args.plot:
+        q_x_full, q_y_full = load_spectrum(query_path)
+        scored = [r for r in results if r.get("score") is not None]
+        plot_overlay(q_x_full, q_y_full, scored, output_dir / "match_plot.png", args.modality)
+
+    if _save_skill_inputs is not None:
+        _save_skill_inputs(args, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/chem-spectrum-matcher/scripts/register_spectrum.py
+++ b/.agents/skills/chem-spectrum-matcher/scripts/register_spectrum.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""
+Register predicted or retrieved spectra into the local spectrum catalog.
+
+Reads a source directory (output of chem-nmr-predict, chem-db-spectra, or a custom
+predictor) and upserts entries keyed by (canonical_smiles, modality) into catalog.json.
+
+Supported modalities: nmr_1h, ir
+
+Usage:
+    # Env: nmr-agent
+    python register_spectrum.py \\
+        --source_dir research/nmr_predictions/ \\
+        --modality nmr_1h \\
+        --catalog_dir research/spectrum_catalog/
+
+    # Env: base-agent  (for IR from chem-db-spectra)
+    python register_spectrum.py \\
+        --source_dir research/ir_references/ \\
+        --modality ir \\
+        --smiles "OC1CC2CCC1C2" \\
+        --names "borneol" \\
+        --catalog_dir research/spectrum_catalog/
+
+Requirements:
+    - Conda environment: nmr-agent (or base-agent for IR-only registration)
+    - Required packages: rdkit
+"""
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
+
+try:
+    from src.utils.config_utils import save_skill_inputs as _save_skill_inputs
+except ImportError:
+    _save_skill_inputs = None
+
+
+def mol_identifiers(smiles: str) -> dict:
+    """
+    Compute canonical SMILES, InChIKey, and InChIKey-14 from a SMILES string.
+
+    InChIKey-14 is the first 14 characters of the InChIKey (connectivity layer only),
+    which ignores stereochemistry and allows diastereomer/enantiomer-insensitive lookup.
+
+    Returns dict with keys: canonical_smiles, inchikey, inchikey14.
+    Raises ValueError if SMILES is invalid.
+    """
+    from rdkit import Chem
+    from rdkit.Chem.inchi import MolToInchiKey, MolToInchi
+
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        raise ValueError(f"Invalid SMILES: {smiles}")
+    canonical = Chem.MolToSmiles(mol)
+    inchi = MolToInchi(mol) or ""
+    inchikey = MolToInchiKey(mol) or ""
+    inchikey14 = inchikey[:14] if inchikey else ""
+    return {
+        "canonical_smiles": canonical,
+        "inchikey": inchikey,
+        "inchikey14": inchikey14,
+    }
+
+
+def canonicalize(smiles: str) -> str:
+    """Return RDKit canonical SMILES, raise ValueError if invalid."""
+    return mol_identifiers(smiles)["canonical_smiles"]
+
+
+def catalog_key(canonical_smiles: str, modality: str) -> str:
+    return f"{canonical_smiles}|{modality}"
+
+
+def load_catalog(catalog_path: pathlib.Path) -> dict:
+    if catalog_path.exists():
+        return json.loads(catalog_path.read_text())
+    return {}
+
+
+def save_catalog(catalog: dict, catalog_path: pathlib.Path) -> None:
+    catalog_path.write_text(json.dumps(catalog, indent=2))
+
+
+def register_from_nmr_predict(
+    source_dir: pathlib.Path,
+    modality: str,
+    catalog: dict,
+    overwrite: bool,
+) -> tuple[int, int]:
+    """
+    Register entries from a chem-nmr-predict output directory.
+
+    Reads predictions.json manifest; each 'found' entry contains smiles + file paths.
+    Returns (registered_count, skipped_count).
+    """
+    manifest_path = source_dir / "predictions.json"
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"predictions.json not found in {source_dir}")
+
+    manifest = json.loads(manifest_path.read_text())
+    found = manifest.get("found", [])
+    registered = skipped = 0
+
+    for entry in found:
+        smiles = entry.get("smiles", "")
+        name = entry.get("name", "")
+        spectrum = entry.get("spectrum", "")
+
+        try:
+            ids = mol_identifiers(smiles)
+        except ValueError as e:
+            print(f"  SKIP {name}: {e}")
+            skipped += 1
+            continue
+
+        key = catalog_key(ids["canonical_smiles"], modality)
+        if key in catalog and not overwrite:
+            print(f"  SKIP {name}: already in catalog (--overwrite to replace)")
+            skipped += 1
+            continue
+
+        catalog[key] = {
+            "name": name,
+            "smiles_input": smiles,
+            "canonical_smiles": ids["canonical_smiles"],
+            "inchikey": ids["inchikey"],
+            "inchikey14": ids["inchikey14"],
+            "modality": modality,
+            "spectrum": str(pathlib.Path(spectrum).resolve()),
+            "signals": str(pathlib.Path(entry.get("signals", "")).resolve()) if entry.get("signals") else "",
+            "n_signals": entry.get("n_signals", 0),
+            "n_atoms_h": entry.get("n_atoms_h", 0),
+            "parameters": manifest.get("parameters", {}),
+        }
+        print(f"  Registered {name} ({ids['canonical_smiles']}) [{modality}]  InChIKey: {ids['inchikey']}")
+        registered += 1
+
+    return registered, skipped
+
+
+def register_from_files(
+    source_dir: pathlib.Path,
+    modality: str,
+    smiles_list: list[str],
+    names: list[str],
+    catalog: dict,
+    overwrite: bool,
+) -> tuple[int, int]:
+    """
+    Register spectrum files by matching filenames to provided SMILES/names.
+
+    Used for IR files from chem-db-spectra or other predictors that do not
+    produce a predictions.json manifest.
+    """
+    registered = skipped = 0
+
+    for smiles, name in zip(smiles_list, names):
+        safe_name = re.sub(r"[^\w\-]", "_", name)[:40]
+
+        try:
+            ids = mol_identifiers(smiles)
+        except ValueError as e:
+            print(f"  SKIP {name}: {e}")
+            skipped += 1
+            continue
+
+        # Find matching spectrum file (prefer .xy, then .jdx, then .csv)
+        candidates = (
+            list(source_dir.glob(f"{safe_name}*.xy"))
+            + list(source_dir.glob(f"{safe_name}*.jdx"))
+            + list(source_dir.glob(f"{safe_name}*.csv"))
+        )
+        if not candidates:
+            print(f"  SKIP {name}: no spectrum file found in {source_dir}")
+            skipped += 1
+            continue
+
+        spectrum_path = candidates[0]
+        key = catalog_key(ids["canonical_smiles"], modality)
+
+        if key in catalog and not overwrite:
+            print(f"  SKIP {name}: already in catalog (--overwrite to replace)")
+            skipped += 1
+            continue
+
+        catalog[key] = {
+            "name": name,
+            "smiles_input": smiles,
+            "canonical_smiles": ids["canonical_smiles"],
+            "inchikey": ids["inchikey"],
+            "inchikey14": ids["inchikey14"],
+            "modality": modality,
+            "spectrum": str(spectrum_path.resolve()),
+            "signals": "",
+            "parameters": {},
+        }
+        print(f"  Registered {name} ({ids['canonical_smiles']}) [{modality}]  InChIKey: {ids['inchikey']}")
+        registered += 1
+
+    return registered, skipped
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Register spectra into the local spectrum catalog."
+    )
+    ap.add_argument(
+        "--source_dir",
+        required=True,
+        help="Directory containing spectrum files (and optionally predictions.json)",
+    )
+    ap.add_argument(
+        "--modality",
+        choices=("nmr_1h", "ir"),
+        required=True,
+        help="Spectrum modality to register under",
+    )
+    ap.add_argument(
+        "--catalog_dir",
+        default="research/spectrum_catalog",
+        help="Local spectrum catalog directory (default: research/spectrum_catalog/)",
+    )
+    ap.add_argument(
+        "--smiles",
+        nargs="+",
+        help="SMILES for each spectrum file (required when no predictions.json present)",
+    )
+    ap.add_argument(
+        "--names",
+        nargs="+",
+        help="Names matching --smiles order (required when no predictions.json present)",
+    )
+    ap.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite existing catalog entries for the same (SMILES, modality)",
+    )
+    args = ap.parse_args()
+
+    source_dir = pathlib.Path(args.source_dir)
+    catalog_dir = pathlib.Path(args.catalog_dir)
+    catalog_dir.mkdir(parents=True, exist_ok=True)
+    catalog_path = catalog_dir / "catalog.json"
+    catalog = load_catalog(catalog_path)
+
+    manifest_path = source_dir / "predictions.json"
+
+    if manifest_path.exists():
+        registered, skipped = register_from_nmr_predict(source_dir, args.modality, catalog, args.overwrite)
+    else:
+        if not args.smiles or not args.names:
+            ap.error("--smiles and --names required when predictions.json is absent in source_dir")
+        if len(args.smiles) != len(args.names):
+            ap.error("--smiles and --names must have equal length")
+        registered, skipped = register_from_files(
+            source_dir, args.modality, args.smiles, args.names, catalog, args.overwrite
+        )
+
+    save_catalog(catalog, catalog_path)
+    print(f"\nDone: {registered} registered, {skipped} skipped.")
+    print(f"Catalog -> {catalog_path} ({len(catalog)} total entries)")
+
+    if _save_skill_inputs is not None:
+        _save_skill_inputs(args, args.catalog_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/conda-envs/msms-agent/README.md
+++ b/conda-envs/msms-agent/README.md
@@ -1,0 +1,25 @@
+# NMR Agent Environment
+
+This environment supports NMR spectrum simulation, mixture analysis, and blind source separation.
+
+## Quick Installation
+Most users should use the simplified installation script, which installs only the necessary core packages:
+
+```bash
+bash install.sh
+```
+
+This installs:
+- python 3.11
+- rdkit
+- numpy, scipy, matplotlib
+- requests
+- nmrsim (NMR spectrum simulation)
+- scikit-learn (PCA/NMF for blind source separation)
+
+## Full Reproduction
+If you need to reproduce the exact environment state (including all pinned dependency versions), use the full example configuration:
+
+```bash
+conda env create -f example_full_env.yaml
+```

--- a/conda-envs/msms-agent/conda_only_env.yaml
+++ b/conda-envs/msms-agent/conda_only_env.yaml
@@ -1,0 +1,25 @@
+name: ms-gen
+channels:
+  - pytorch
+  - dglteam
+  - conda-forge
+  - pyg
+  - defaults
+dependencies:
+  - python=3.8
+  - cython
+  - matplotlib=3.4.*
+  - rdkit=2021.03.*
+  - conda-forge::python-graphviz=0.17
+  - conda-forge::pygraphviz=1.7
+  - pytorch-lightning=1.6.*
+  - pip=21.2.*
+  - pytorch::pytorch=1.9.1=py3.8_cuda11.1_cudnn8.0.5_0
+  - cudatoolkit=11.1
+  - einops
+  - seaborn=0.11.*
+  - pytorch-scatter
+  - pytorch-sparse
+  - pyg
+  - dgl-cuda11.1=0.8.2
+  - h5py

--- a/conda-envs/msms-agent/conda_only_env.yaml
+++ b/conda-envs/msms-agent/conda_only_env.yaml
@@ -1,25 +1,17 @@
 name: ms-gen
 channels:
   - pytorch
-  - dglteam
   - conda-forge
-  - pyg
   - defaults
 dependencies:
-  - python=3.8
+  - python=3.10
   - cython
-  - matplotlib=3.4.*
-  - rdkit=2021.03.*
-  - conda-forge::python-graphviz=0.17
-  - conda-forge::pygraphviz=1.7
-  - pytorch-lightning=1.6.*
-  - pip=21.2.*
-  - pytorch::pytorch=1.9.1=py3.8_cuda11.1_cudnn8.0.5_0
-  - cudatoolkit=11.1
+  - matplotlib
+  - conda-forge::rdkit
+  - conda-forge::python-graphviz
+  - conda-forge::pygraphviz
+  - pytorch::pytorch=2.4.0
+  - pip
   - einops
-  - seaborn=0.11.*
-  - pytorch-scatter
-  - pytorch-sparse
-  - pyg
-  - dgl-cuda11.1=0.8.2
+  - seaborn
   - h5py

--- a/conda-envs/msms-agent/core_env.yaml
+++ b/conda-envs/msms-agent/core_env.yaml
@@ -1,32 +1,25 @@
 name: ms-gen
 channels:
   - pytorch
-  - dglteam
   - conda-forge
-  - pyg
   - defaults
 dependencies:
-  - python=3.8
+  - python=3.10
   - cython
-  - matplotlib=3.4.*
-  - rdkit=2021.03.*
-  - conda-forge::python-graphviz=0.17
-  - conda-forge::pygraphviz=1.7
-  - pytorch-lightning=1.6.*
-  - pip=21.2.*
-  - pytorch::pytorch=1.9.1=py3.8_cuda11.1_cudnn8.0.5_0
-  - cudatoolkit=11.1
+  - matplotlib
+  - conda-forge::rdkit
+  - conda-forge::python-graphviz
+  - conda-forge::pygraphviz
+  - pytorch::pytorch=2.4.0
+  - pip
   - einops
-  - seaborn=0.11.*
-  - pytorch-scatter
-  - pytorch-sparse
-  - pyg
-  - dgl-cuda11.1=0.8.2
+  - seaborn
   - h5py
   - pip:
+    - dgl -f https://data.dgl.ai/wheels/torch-2.4/repo.html
+    - pytorch-lightning
     - scikit-learn
     - pathos
-    - "setuptools==59.5.0"
     - CairoSVG
     - omegaconf
     - pubchempy

--- a/conda-envs/msms-agent/core_env.yaml
+++ b/conda-envs/msms-agent/core_env.yaml
@@ -1,0 +1,37 @@
+name: ms-gen
+channels:
+  - pytorch
+  - dglteam
+  - conda-forge
+  - pyg
+  - defaults
+dependencies:
+  - python=3.8
+  - cython
+  - matplotlib=3.4.*
+  - rdkit=2021.03.*
+  - conda-forge::python-graphviz=0.17
+  - conda-forge::pygraphviz=1.7
+  - pytorch-lightning=1.6.*
+  - pip=21.2.*
+  - pytorch::pytorch=1.9.1=py3.8_cuda11.1_cudnn8.0.5_0
+  - cudatoolkit=11.1
+  - einops
+  - seaborn=0.11.*
+  - pytorch-scatter
+  - pytorch-sparse
+  - pyg
+  - dgl-cuda11.1=0.8.2
+  - h5py
+  - pip:
+    - scikit-learn
+    - pathos
+    - "setuptools==59.5.0"
+    - CairoSVG
+    - omegaconf
+    - pubchempy
+    - pygmtools
+    - msbuddy
+    - lightgbm
+    - platformdirs
+    - pyyaml

--- a/conda-envs/msms-agent/install.sh
+++ b/conda-envs/msms-agent/install.sh
@@ -25,14 +25,20 @@ conda activate $ENV_NAME
 echo "Installing pip dependencies with uv..."
 uv pip install -r uv_requirements.txt
 
+# torch-scatter / torch-sparse: no generic arm64 wheels on PyPI.
+# Use the PyG find-links index pinned to torch 2.4.0+cpu.
+TORCH_VERSION=$(python -c "import torch; print(torch.__version__.split('+')[0])")
+PYG_INDEX="https://data.pyg.org/whl/torch-${TORCH_VERSION}+cpu.html"
+echo "Installing torch-scatter and torch-sparse from PyG index (torch ${TORCH_VERSION})..."
+uv pip install torch-scatter torch-sparse --find-links "$PYG_INDEX"
+
 # Install ms_pred from GitHub.
-# setup.py has a Cython ext (massformer only) that breaks standard install,
-# so we clone, patch setup.py to skip the ext, then install pure-Python package.
+# setup.py includes a Cython extension for massformer (not used by ICEBERG),
+# so we clone, replace setup.py with a pure-Python version, then install.
 echo "Installing ms_pred from GitHub..."
 TMP_DIR=$(mktemp -d)
 git clone --depth 1 https://github.com/coleygroup/ms-pred "$TMP_DIR/ms-pred"
 
-# Patch: replace setup.py with a Cython-free version
 cat > "$TMP_DIR/ms-pred/setup.py" << 'SETUP_EOF'
 from setuptools import setup, find_packages
 setup(

--- a/conda-envs/msms-agent/install.sh
+++ b/conda-envs/msms-agent/install.sh
@@ -11,7 +11,7 @@ sed '/^[[:space:]]*- pip:/,$d' core_env.yaml > conda_only_env.yaml
 conda env remove -n $ENV_NAME -y || true
 conda env create -f conda_only_env.yaml
 
-sed -n '/^[[:space:]]*- pip:/,$p' core_env.yaml | grep -v 'pip:' | sed 's/^[[:space:]]*- //' | tr -d '"' | tr -d "'" > uv_requirements.txt
+sed -n '/^[[:space:]]*- pip:/,$p' core_env.yaml | grep -v 'pip:' | sed 's/^[[:space:]]*- //' | tr -d '"' | tr -d "'" | grep -v '^dgl ' > uv_requirements.txt
 
 if ! command -v uv &> /dev/null; then
     echo "Installing uv..."
@@ -21,6 +21,9 @@ fi
 
 source $(conda info --base)/etc/profile.d/conda.sh
 conda activate $ENV_NAME
+
+echo "Installing dgl from custom index..."
+uv pip install dgl --find-links https://data.dgl.ai/wheels/torch-2.4/repo.html
 
 echo "Installing pip dependencies with uv..."
 uv pip install -r uv_requirements.txt
@@ -40,11 +43,11 @@ TMP_DIR=$(mktemp -d)
 git clone --depth 1 https://github.com/coleygroup/ms-pred "$TMP_DIR/ms-pred"
 
 cat > "$TMP_DIR/ms-pred/setup.py" << 'SETUP_EOF'
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 setup(
     name='ms_pred',
     version='0.0.1',
-    packages=find_packages(where='src'),
+    packages=find_namespace_packages(where='src'),
     package_dir={'': 'src'},
     include_package_data=True,
 )

--- a/conda-envs/msms-agent/install.sh
+++ b/conda-envs/msms-agent/install.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR"
+
+ENV_NAME=$(grep -e '^name:' core_env.yaml | awk '{print $2}')
+echo "Creating Conda environment $ENV_NAME..."
+
+sed '/^[[:space:]]*- pip:/,$d' core_env.yaml > conda_only_env.yaml
+conda env remove -n $ENV_NAME -y || true
+conda env create -f conda_only_env.yaml
+
+sed -n '/^[[:space:]]*- pip:/,$p' core_env.yaml | grep -v 'pip:' | sed 's/^[[:space:]]*- //' | tr -d '"' | tr -d "'" > uv_requirements.txt
+
+if ! command -v uv &> /dev/null; then
+    echo "Installing uv..."
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
+fi
+
+source $(conda info --base)/etc/profile.d/conda.sh
+conda activate $ENV_NAME
+
+echo "Installing pip dependencies with uv..."
+uv pip install -r uv_requirements.txt
+
+# Install ms_pred from GitHub.
+# setup.py has a Cython ext (massformer only) that breaks standard install,
+# so we clone, patch setup.py to skip the ext, then install pure-Python package.
+echo "Installing ms_pred from GitHub..."
+TMP_DIR=$(mktemp -d)
+git clone --depth 1 https://github.com/coleygroup/ms-pred "$TMP_DIR/ms-pred"
+
+# Patch: replace setup.py with a Cython-free version
+cat > "$TMP_DIR/ms-pred/setup.py" << 'SETUP_EOF'
+from setuptools import setup, find_packages
+setup(
+    name='ms_pred',
+    version='0.0.1',
+    packages=find_packages(where='src'),
+    package_dir={'': 'src'},
+    include_package_data=True,
+)
+SETUP_EOF
+
+uv pip install "$TMP_DIR/ms-pred"
+rm -rf "$TMP_DIR"
+
+rm -f conda_only_env.yaml uv_requirements.txt
+echo "Environment $ENV_NAME created successfully!"


### PR DESCRIPTION
This PR introduces two features: predicting tandem mass spectra (MS/MS) and matching predicted or experimental spectra to a spectral database according to set similarity criteria.

- `chem-msms-predict`: Predict mass spectra with the current state-of-the-art model ICEBERG (https://github.com/coleygroup/ms-pred). It requires a checkpoint to be loaded (link to said checkpoint in skill, needs to be downloaded by user), and the new `msms-agent` environment to be installed.
- `chem-spectrum-matcher` --> this is a generalization/different angle of looking at retrieval from a spectral database, compared to `chem-nmr-analysis`. In short, given a predicted or experimental spectrum, the agent queries this spectrum against a database of spectra by (i) binning the spectrum and (ii) calculating similarities (cosine, entropy).