### PR TITLE
feat: biorxiv api search skill

### DIFF
--- a/.agents/skills/general-biorxiv-search/SKILL.md
+++ b/.agents/skills/general-biorxiv-search/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: general-biorxiv-search
+description: Search and retrieve preprint metadata from bioRxiv and medRxiv APIs for biological and medical research.
+category: general
+---
+
+# bioRxiv / medRxiv Search
+
+## Goal
+Search and retrieve preprint metadata (title, authors, abstract, DOI, category, etc.) from bioRxiv and medRxiv using the official REST API. Supports keyword filtering, subject category filtering, date-range search, and DOI lookup.
+
+## Instructions
+
+### 1. Keyword Search (Recent Papers)
+Search last 30 days for papers matching keywords in title/abstract.
+
+```bash
+# Env: base-agent
+python .agents/skills/general-biorxiv-search/scripts/biorxiv_search.py "protein folding" --max_results 5 --output protein_folding.json
+```
+
+### 2. Date Range Search
+Retrieve preprints posted in a specific date range, with optional keyword/category filter.
+
+```bash
+# Env: base-agent
+python .agents/skills/general-biorxiv-search/scripts/biorxiv_search.py "CRISPR" --start 2025-01-01 --end 2025-06-01 --max_results 10 --output crispr_2025.json
+```
+
+### 3. Category Filter
+Filter by subject category (use shortcuts or full names).
+
+```bash
+# Env: base-agent
+python .agents/skills/general-biorxiv-search/scripts/biorxiv_search.py --category neuroscience --days 14 --max_results 10
+```
+
+**Supported Category Shortcuts:**
+- `biochemistry`, `bioinformatics`, `biophysics`
+- `cancer` → cancer_biology
+- `cell-bio` → cell_biology
+- `dev-bio` → developmental_biology
+- `ecology`, `epidemiology`, `evolution`
+- `genetics`, `genomics`, `immunology`
+- `microbiology`, `molecular-bio` → molecular_biology
+- `neuroscience`, `pharmacology`, `physiology`
+- `plant-bio` → plant_biology
+- `synthetic-bio` → synthetic_biology
+- `systems-bio` → systems_biology
+
+### 4. Search medRxiv
+Use `--server medrxiv` for medical preprints.
+
+```bash
+# Env: base-agent
+python .agents/skills/general-biorxiv-search/scripts/biorxiv_search.py "COVID vaccine efficacy" --server medrxiv --max_results 5 --output covid_vaccine.json
+```
+
+### 5. DOI Lookup
+Retrieve metadata for a specific preprint by DOI.
+
+```bash
+# Env: base-agent
+python .agents/skills/general-biorxiv-search/scripts/biorxiv_search.py --doi 10.1101/2021.01.01.000000 --output paper.json
+```
+
+## Examples
+
+### Recent Neuroscience Papers
+```bash
+# Env: base-agent
+python .agents/skills/general-biorxiv-search/scripts/biorxiv_search.py --category neuroscience --days 7 --max_results 5
+```
+
+### Genomics Papers with Keyword Filter
+```bash
+# Env: base-agent
+python .agents/skills/general-biorxiv-search/scripts/biorxiv_search.py "single cell sequencing" --category genomics --start 2024-01-01 --end 2024-12-31 --max_results 10 --output scrna_2024.json
+```
+
+## Constraints
+- **No official rate limit** specified by bioRxiv API; script includes 0.5s delay per request as courtesy.
+- **Pagination**: API returns 30 results per page; script paginates automatically up to `--max_results`.
+- **Keyword filtering**: Done client-side (API lacks full-text search); date range must be broad enough to surface relevant papers.
+- **Environment**: Requires `base-agent` conda environment.
+- **Dependencies**: Uses `requests`.
+- **Metadata fields**: DOI, URL, title, authors, abstract, date, category, server, version, license, published journal (if available).
+
+---
+
+**Author:** mlederbauer
+**Contact:** [GitHub @learningmatter-mit](https://github.com/learningmatter-mit)

--- a/.agents/skills/general-biorxiv-search/scripts/biorxiv_search.py
+++ b/.agents/skills/general-biorxiv-search/scripts/biorxiv_search.py
@@ -1,0 +1,274 @@
+"""
+bioRxiv / medRxiv Search Tool
+Search and retrieve preprint metadata from bioRxiv and medRxiv via the official API.
+
+Usage:
+    python biorxiv_search.py "CRISPR gene editing" --max_results 5 --output results.json
+    python biorxiv_search.py --category neuroscience --days 30 --max_results 10
+    python biorxiv_search.py --server medrxiv "COVID vaccine" --max_results 5
+
+Requirements:
+    - Conda environment: base-agent
+    - Required packages: requests
+"""
+
+import sys
+import argparse
+import json
+import time
+import urllib.parse
+from typing import List, Dict, Any, Optional
+
+import requests
+
+
+class BioRxivSearcher:
+    """Interface for bioRxiv/medRxiv preprint search via the official API."""
+
+    BASE_URL = "https://api.biorxiv.org/details/{server}/{interval}/{cursor}/json"
+    SEARCH_URL = "https://api.biorxiv.org/details/{server}/{interval}/{cursor}/json"
+
+    # bioRxiv subject categories
+    CATEGORIES = {
+        "biochemistry": "biochemistry",
+        "bioinformatics": "bioinformatics",
+        "biophysics": "biophysics",
+        "cancer": "cancer_biology",
+        "cell-bio": "cell_biology",
+        "dev-bio": "developmental_biology",
+        "ecology": "ecology",
+        "epidemiology": "epidemiology",
+        "evolution": "evolutionary_biology",
+        "genetics": "genetics",
+        "genomics": "genomics",
+        "immunology": "immunology",
+        "microbiology": "microbiology",
+        "molecular-bio": "molecular_biology",
+        "neuroscience": "neuroscience",
+        "pharmacology": "pharmacology",
+        "physiology": "physiology",
+        "plant-bio": "plant_biology",
+        "synthetic-bio": "synthetic_biology",
+        "systems-bio": "systems_biology",
+    }
+
+    def __init__(self, server: str = "biorxiv", verbose: bool = False):
+        self.server = server.lower()
+        self.verbose = verbose
+
+    def _log(self, message: str):
+        if self.verbose:
+            print(f"[INFO] {message}", file=sys.stderr)
+
+    def _fetch_page(self, interval: str, cursor: int = 0) -> Dict[str, Any]:
+        """Fetch one page (up to 30 results) from bioRxiv API."""
+        url = self.BASE_URL.format(
+            server=self.server,
+            interval=urllib.parse.quote(interval, safe="/"),
+            cursor=cursor,
+        )
+        self._log(f"Requesting: {url}")
+        time.sleep(0.5)
+        response = requests.get(url, timeout=30)
+        response.raise_for_status()
+        return response.json()
+
+    def search_by_date_range(
+        self,
+        start_date: str,
+        end_date: str,
+        keywords: Optional[List[str]] = None,
+        category: Optional[str] = None,
+        max_results: int = 10,
+    ) -> List[Dict[str, Any]]:
+        """
+        Retrieve preprints posted in a date range, optionally filtered by keyword/category.
+
+        Args:
+            start_date: Start date YYYY-MM-DD.
+            end_date: End date YYYY-MM-DD.
+            keywords: Filter results whose title or abstract contain all keywords.
+            category: bioRxiv subject category (use CATEGORIES shortcuts or full name).
+            max_results: Max papers to return.
+
+        Returns:
+            List of paper dicts.
+        """
+        interval = f"{start_date}/{end_date}"
+        papers = []
+        cursor = 0
+
+        while len(papers) < max_results:
+            data = self._fetch_page(interval, cursor)
+            collection = data.get("collection", [])
+            if not collection:
+                break
+
+            for item in collection:
+                if len(papers) >= max_results:
+                    break
+                paper = self._parse_item(item)
+                if self._matches(paper, keywords, category):
+                    papers.append(paper)
+
+            total = int(data.get("messages", [{}])[0].get("total", 0))
+            cursor += 30
+            if cursor >= total:
+                break
+
+        self._log(f"Found {len(papers)} papers")
+        return papers
+
+    def search_recent(
+        self,
+        days: int = 30,
+        keywords: Optional[List[str]] = None,
+        category: Optional[str] = None,
+        max_results: int = 10,
+    ) -> List[Dict[str, Any]]:
+        """
+        Retrieve preprints from last N days, optionally filtered.
+
+        Args:
+            days: Number of recent days to search.
+            keywords: Filter by keywords in title/abstract.
+            category: Subject category filter.
+            max_results: Max papers to return.
+        """
+        interval = f"{days}d"
+        papers = []
+        cursor = 0
+
+        while len(papers) < max_results:
+            data = self._fetch_page(interval, cursor)
+            collection = data.get("collection", [])
+            if not collection:
+                break
+
+            for item in collection:
+                if len(papers) >= max_results:
+                    break
+                paper = self._parse_item(item)
+                if self._matches(paper, keywords, category):
+                    papers.append(paper)
+
+            total = int(data.get("messages", [{}])[0].get("total", 0))
+            cursor += 30
+            if cursor >= total:
+                break
+
+        self._log(f"Found {len(papers)} papers")
+        return papers
+
+    def search_by_doi(self, doi: str) -> Optional[Dict[str, Any]]:
+        """Retrieve metadata for a specific preprint by DOI."""
+        url = self.BASE_URL.format(server=self.server, interval=doi, cursor=0)
+        self._log(f"Requesting DOI: {url}")
+        time.sleep(0.5)
+        response = requests.get(url, timeout=30)
+        response.raise_for_status()
+        data = response.json()
+        collection = data.get("collection", [])
+        if collection:
+            return self._parse_item(collection[0])
+        return None
+
+    def _parse_item(self, item: Dict[str, Any]) -> Dict[str, Any]:
+        """Normalize API response item to standard paper dict."""
+        doi = item.get("doi", "")
+        return {
+            "doi": doi,
+            "url": f"https://www.biorxiv.org/content/{doi}v{item.get('version', 1)}" if doi else "",
+            "title": item.get("title", "").strip(),
+            "authors": item.get("authors", "").strip(),
+            "abstract": item.get("abstract", "").strip(),
+            "date": item.get("date", ""),
+            "category": item.get("category", ""),
+            "server": item.get("server", self.server),
+            "version": item.get("version", ""),
+            "license": item.get("license", ""),
+            "published": item.get("published", ""),
+        }
+
+    def _matches(
+        self,
+        paper: Dict[str, Any],
+        keywords: Optional[List[str]],
+        category: Optional[str],
+    ) -> bool:
+        """Check if paper matches keyword and category filters."""
+        if category:
+            full_cat = self.CATEGORIES.get(category, category)
+            if full_cat.lower() not in paper.get("category", "").lower():
+                return False
+
+        if keywords:
+            text = (paper.get("title", "") + " " + paper.get("abstract", "")).lower()
+            for kw in keywords:
+                if kw.lower() not in text:
+                    return False
+
+        return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Search bioRxiv/medRxiv for preprints.")
+    parser.add_argument("query", nargs="?", help="Keywords to search in title/abstract")
+    parser.add_argument(
+        "--server",
+        default="biorxiv",
+        choices=["biorxiv", "medrxiv"],
+        help="Preprint server (default: biorxiv)",
+    )
+    parser.add_argument("--category", help="Subject category (e.g. neuroscience, genetics)")
+    parser.add_argument("--days", type=int, default=30, help="Search last N days (default: 30)")
+    parser.add_argument("--start", help="Start date YYYY-MM-DD for date range search")
+    parser.add_argument("--end", help="End date YYYY-MM-DD for date range search")
+    parser.add_argument("--doi", help="Retrieve specific preprint by DOI")
+    parser.add_argument("--max_results", type=int, default=10, help="Max results to return")
+    parser.add_argument("--output", help="Path to save results as JSON")
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
+
+    args = parser.parse_args()
+
+    searcher = BioRxivSearcher(server=args.server, verbose=args.verbose)
+    keywords = args.query.split() if args.query else None
+
+    if args.doi:
+        result = searcher.search_by_doi(args.doi)
+        results = [result] if result else []
+    elif args.start and args.end:
+        results = searcher.search_by_date_range(
+            start_date=args.start,
+            end_date=args.end,
+            keywords=keywords,
+            category=args.category,
+            max_results=args.max_results,
+        )
+    else:
+        results = searcher.search_recent(
+            days=args.days,
+            keywords=keywords,
+            category=args.category,
+            max_results=args.max_results,
+        )
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(results, f, indent=2, ensure_ascii=False)
+        print(f"Saved {len(results)} results to {args.output}")
+    else:
+        for i, paper in enumerate(results, 1):
+            print(f"\n[{i}] {paper['title']}")
+            authors = paper.get("authors", "")
+            print(f"    Authors: {authors[:100]}{'...' if len(authors) > 100 else ''}")
+            print(f"    DOI: {paper['doi']} | Date: {paper['date']} | Category: {paper['category']}")
+            print(f"    URL: {paper['url']}")
+
+    from src.utils.config_utils import save_skill_inputs
+
+    save_skill_inputs(args, args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Parses through preprint servers, similarly to `general-arxiv-search`. This is based on the public bioRxiv API: https://api.biorxiv.org/. Note that this can be expanded to MedRxiv extremely easily -- if of interest, this can be extended! (Replacing "bio" with "med" and adapting the categories will do the job).