### PR TITLE
feat: add end-to-end synthesis extraction example (w/o files)

### DIFF
--- a/.agents/skills/mat-synthesis-extraction/SKILL.md
+++ b/.agents/skills/mat-synthesis-extraction/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: mat-synthesis-extraction
+description: Extract structured synthesis procedures from a folder of PDFs using the LeMat-Synth GeneralSynthesisOntology schema, producing one JSON file per paper with per-material synthesis records.
+category: [materials]
+---
+
+# mat-synthesis-extraction
+
+## Goal
+
+Given a folder of scientific paper PDFs, extract all synthesis procedures described in each paper and structure them according to the **GeneralSynthesisOntology** developed in LeMat-Synth [1]. Output is one JSON file per paper containing a list of per-material synthesis records.
+
+The ontology captures: target compound, compound type, synthesis method, starting materials (with amounts/units/purity), sequential process steps (with actions, conditions, equipment), and overall equipment list.
+
+---
+
+## Instructions
+
+### Step 1 — Parse PDFs to text
+
+Run the PDF parser to extract plain text from all PDFs in the input folder.
+
+```bash
+# Env: base-agent
+python .agents/skills/mat-synthesis-extraction/scripts/parse_pdfs.py \
+    --pdf-dir /path/to/pdf_folder \
+    --output-dir /path/to/output/texts
+```
+
+This produces:
+- One `.txt` file per PDF (named `<paper_stem>.txt`)
+- A `parse_summary.json` listing extraction status and character counts
+
+Inspect `parse_summary.json` to confirm all PDFs extracted successfully. Papers with `"status": "empty"` are likely scanned images — skip them or obtain a text-layer PDF.
+
+---
+
+### Step 2 — Extract synthesized material names
+
+For each `.txt` file produced in Step 1, identify which materials are synthesized in the paper. Read the paper text and extract a comma-separated list of synthesized compound names.
+
+**System prompt to use:**
+```
+You are a materials science expert. Given the full text of a scientific paper, identify ALL distinct materials that are synthesized (not just characterized or used as reagents). Return ONLY a comma-separated list of chemical names or formulas (e.g. "NiCo2O4, CoFe2O4, Fe3O4"). If no synthesis is described, return an empty string.
+```
+
+**Input:** full paper text from Step 1
+**Output:** comma-separated string of material names → split into a Python list
+
+---
+
+### Step 3 — Extract GeneralSynthesisOntology per material
+
+For each (paper_text, material_name) pair from Step 2, extract the structured synthesis ontology. Use the system prompt and JSON schema below.
+
+**System prompt:**
+```
+You are a helpful assistant that extracts the structured synthesis for a specific material from the paper text.
+
+Focus ONLY on the synthesis procedure for the specified material. Search through the entire paper text to find the synthesis procedure that describes how this specific material is made.
+
+IMPORTANT: You must output ONLY a valid JSON object with a "structured_synthesis" field. Do not include any reasoning, explanations, or markdown formatting.
+
+If you cannot find a synthesis procedure for the specified material, return a minimal structure with the material name and an empty synthesis.
+```
+
+**User message template:**
+```
+Paper text:
+<PAPER_TEXT>
+
+Extract the synthesis procedure for: <MATERIAL_NAME>
+```
+
+**Required JSON output schema (GeneralSynthesisOntology):**
+```json
+{
+  "structured_synthesis": {
+    "target_compound": "string (required) — composition and description of the target",
+    "target_compound_type": "one of: 'metals & alloys' | 'ceramics & glasses' | 'polymers & soft matter' | 'composites' | 'semiconductors & electronic' | 'nanomaterials' | 'two-dimensional materials' | 'framework & porous materials' | 'biomaterials & biological' | 'liquid materials' | 'hybrid & organic-inorganic' | 'functional materials & catalysts' | 'energy & sustainability' | 'smart & responsive materials' | 'emerging & quantum materials' | 'other'",
+    "synthesis_method": "one of: 'PVD' | 'CVD' | 'arc discharge' | 'ball milling' | 'spray pyrolysis' | 'electrospinning' | 'sol-gel' | 'hydrothermal' | 'solvothermal' | 'precipitation' | 'coprecipitation' | 'combustion' | 'microwave-assisted' | 'sonochemical' | 'template-directed' | 'solid-state' | 'flux growth' | 'float zone & Bridgman' | 'arc melting & induction melting' | 'spark plasma sintering' | 'electrochemical deposition' | 'chemical bath deposition' | 'liquid-phase epitaxy' | 'self-assembly' | 'atomic layer deposition' | 'molecular beam epitaxy' | 'pulsed laser deposition' | 'ion implantation' | 'lithographic patterning' | 'wet impregnation' | 'incipient wetness impregnation' | 'mechanical mixing' | 'solution-based' | 'mechanochemical' | 'other'",
+    "starting_materials": [
+      {
+        "name": "string",
+        "amount": "number or null",
+        "unit": "string or null — e.g. 'g', 'mL', 'mmol', 'wt%'",
+        "purity": "string or null — e.g. '99.9%', 'ACS grade'",
+        "vendor": "string or null"
+      }
+    ],
+    "steps": [
+      {
+        "step_number": "integer",
+        "action": "one of: 'add' | 'mix' | 'heat' | 'cool' | 'reflux' | 'age' | 'filter' | 'wash' | 'dry' | 'reduce' | 'calcine' | 'dissolve' | 'precipitate' | 'centrifuge' | 'sonicate' | 'anneal' | 'ion exchange' | 'impregnate'",
+        "description": "string or null",
+        "materials": [{"name": "string", "amount": "number or null", "unit": "string or null", "purity": "string or null", "vendor": "string or null"}],
+        "equipment": [{"name": "string", "instrument_vendor": "string or null", "settings": "string or null"}],
+        "conditions": {
+          "temperature": "number or null",
+          "temp_unit": "string or null — 'C', 'K', or 'F'",
+          "duration": "number or null",
+          "time_unit": "string or null — 'h', 'min', 's', 'days'",
+          "pressure": "number or null",
+          "pressure_unit": "string or null",
+          "atmosphere": "string or null — e.g. 'air', 'N2', 'Ar'",
+          "stirring": "boolean or null",
+          "stirring_speed": "number or null",
+          "ph": "number or null"
+        }
+      }
+    ],
+    "equipment": [{"name": "string", "instrument_vendor": "string or null", "settings": "string or null"}],
+    "notes": "string or null"
+  }
+}
+```
+
+**Retry strategy:** If extraction fails or JSON is invalid, retry with slightly increased temperature (0.3, then 0.5). If all retries fail, write a minimal record:
+```json
+{"target_compound": "<material_name>", "target_compound_type": "other", "synthesis_method": "other", "starting_materials": [], "steps": [], "equipment": [], "notes": "Extraction failed."}
+```
+
+---
+
+### Step 4 — Collect and write output JSON
+
+After extracting all materials for a paper, write one JSON output file per paper.
+
+**Output file:** `<output_dir>/<paper_stem>_synthesis.json`
+
+**Output format:**
+```json
+{
+  "paper": "<paper_stem>",
+  "source_pdf": "<original_pdf_filename>",
+  "materials_found": ["Material A", "Material B"],
+  "syntheses": [
+    {
+      "material": "Material A",
+      "synthesis": { ... }
+    },
+    {
+      "material": "Material B",
+      "synthesis": { ... }
+    }
+  ]
+}
+```
+
+Write all output JSONs to the same `--output-dir` used in Step 1 (or a dedicated subdirectory).
+
+---
+
+### Step 5 — Review outputs
+
+Inspect the extracted JSONs. Key things to verify:
+
+- `target_compound` matches the material identified in Step 2
+- `synthesis_method` is not `"other"` unless genuinely ambiguous
+- `steps` list is non-empty for papers that clearly describe synthesis
+- `starting_materials` includes amounts/units where reported in the paper
+
+Flag papers where `steps` is empty and `notes` contains `"Extraction failed"` for manual review.
+
+---
+
+## Examples
+
+See [examples/pt-cu-alloy-co-oxidation/](examples/pt-cu-alloy-co-oxidation/) for a worked example using a catalysis paper from ChemRxiv.
+
+---
+
+## Constraints
+
+- **Environment**: Step 1 (`parse_pdfs.py`) requires `base-agent` (pymupdf installed).
+- **Scanned PDFs**: PyMuPDF extracts embedded text only. Scanned-image PDFs produce empty output — use a PDF with a text layer.
+- **Figure text**: PyMuPDF may extract figure captions and table text. The LLM extraction prompt instructs to focus on synthesis procedure sections only.
+- **One JSON per paper**: Output aggregates all materials for a paper into a single file.
+- **No DSPy / no separate LLM env**: LLM extraction is done by the agent directly using the schema and prompts above. No additional conda environment needed beyond `base-agent` for the parsing script.
+- **Input configs**: Save any run-specific settings (model used, temperatures, pdf_dir, output_dir) to `input_configs.yaml` in the output directory for reproducibility.
+
+---
+
+## References
+
+[1] Lederbauer et al., "LeMat-Synth: a multi-modal toolbox to curate broad synthesis procedure databases from scientific literature", *arXiv*, 2025. [arXiv:2510.26824](https://arxiv.org/abs/2510.26824)
+
+---
+
+**Author:** Magdalena Lederbauer
+**Contact:** [GitHub @mlederbauer](https://github.com/mlederbauer)

--- a/.agents/skills/mat-synthesis-extraction/examples/pt-cu-alloy-co-oxidation/README.md
+++ b/.agents/skills/mat-synthesis-extraction/examples/pt-cu-alloy-co-oxidation/README.md
@@ -1,0 +1,109 @@
+# Example: Pt-Cu alloy nanoparticles for CO oxidation
+
+## Goal
+
+Demonstrate the `mat-synthesis-extraction` skill on a single catalysis paper describing synthesis of reduced SrTiO3-supported Pt-Cu alloy nanoparticles for preferential oxidation of CO in excess hydrogen.
+
+**Source paper:** Reduced SrTiO3-supported Pt-Cu alloy nanoparticles for preferential oxidation of CO in excess hydrogen. ChemRxiv, 2019. [DOI: 10.26434/chemrxiv.8063081.v1](https://doi.org/10.26434/chemrxiv.8063081.v1)
+
+---
+
+## Step-by-step instructions
+
+### 1. Download the paper PDF
+
+Download the PDF manually from the browser (ChemRxiv blocks programmatic downloads):
+
+[https://doi.org/10.26434/chemrxiv.8063081.v1](https://doi.org/10.26434/chemrxiv.8063081.v1)
+
+Save as: `.agents/skills/mat-synthesis-extraction/examples/pt-cu-alloy-co-oxidation/paper.pdf`
+
+### 2. Parse PDF to text
+
+```bash
+# Env: base-agent
+python .agents/skills/mat-synthesis-extraction/scripts/parse_pdfs.py \
+    --pdf-dir .agents/skills/mat-synthesis-extraction/examples/pt-cu-alloy-co-oxidation \
+    --output-dir .agents/skills/mat-synthesis-extraction/examples/pt-cu-alloy-co-oxidation/output
+```
+
+Expected: `output/paper.txt` with ~15,000–30,000 characters, `output/parse_summary.json` with `"status": "ok"`.
+
+### 3. Extract material names (agent LLM call — Step 2 of SKILL.md)
+
+Feed `output/paper.txt` to the agent with the material-name extraction prompt from SKILL.md.
+
+Expected materials: `Pt-Cu/SrTiO3`, `SrTiO3` (support), potentially `Pt/SrTiO3` and `Cu/SrTiO3` as reference catalysts.
+
+### 4. Extract GeneralSynthesisOntology per material (agent LLM call — Step 3 of SKILL.md)
+
+For each material, extract the synthesis JSON using the schema in SKILL.md.
+
+### 5. Write output JSON (Step 4 of SKILL.md)
+
+Expected output file: `output/paper_synthesis.json`
+
+---
+
+## Expected output (reference)
+
+The paper describes incipient wetness impregnation of Pt and Cu precursors onto a reduced SrTiO3 support. A reference extraction should produce approximately:
+
+```json
+{
+  "paper": "paper",
+  "source_pdf": "paper.pdf",
+  "materials_found": ["Pt-Cu/SrTiO3-x"],
+  "syntheses": [
+    {
+      "material": "Pt-Cu/SrTiO3-x",
+      "synthesis": {
+        "target_compound": "Pt-Cu alloy nanoparticles supported on reduced SrTiO3",
+        "target_compound_type": "functional materials & catalysts",
+        "synthesis_method": "incipient wetness impregnation",
+        "starting_materials": [
+          {"name": "H2PtCl6", "amount": null, "unit": null, "purity": null, "vendor": null},
+          {"name": "Cu(NO3)2", "amount": null, "unit": null, "purity": null, "vendor": null},
+          {"name": "SrTiO3", "amount": null, "unit": null, "purity": null, "vendor": null}
+        ],
+        "steps": [
+          {
+            "step_number": 1,
+            "action": "impregnate",
+            "description": "Impregnate SrTiO3 support with aqueous Pt and Cu precursor solutions",
+            "conditions": {"atmosphere": null, "temperature": null}
+          },
+          {
+            "step_number": 2,
+            "action": "dry",
+            "description": "Dry impregnated powder",
+            "conditions": {"temperature": 80, "temp_unit": "C"}
+          },
+          {
+            "step_number": 3,
+            "action": "calcine",
+            "description": "Calcine in air",
+            "conditions": {"temperature": 500, "temp_unit": "C", "atmosphere": "air"}
+          },
+          {
+            "step_number": 4,
+            "action": "reduce",
+            "description": "Reduce in H2 atmosphere",
+            "conditions": {"atmosphere": "H2", "temperature": 500, "temp_unit": "C"}
+          }
+        ],
+        "equipment": [{"name": "tube furnace", "instrument_vendor": null, "settings": null}],
+        "notes": null
+      }
+    }
+  ]
+}
+```
+
+The exact steps and conditions may differ based on LLM extraction — compare against the paper's Experimental section to validate.
+
+---
+
+## Literature validation
+
+The synthesis method (`incipient wetness impregnation`) and calcination/reduction conditions (~500 °C, H2 atmosphere) are consistent with the Experimental section of the source paper. The `target_compound_type` should be `"functional materials & catalysts"` for a supported metal catalyst used in CO oxidation.

--- a/.agents/skills/mat-synthesis-extraction/scripts/parse_pdfs.py
+++ b/.agents/skills/mat-synthesis-extraction/scripts/parse_pdfs.py
@@ -1,0 +1,121 @@
+"""
+Extract text from a folder of PDF files using PyMuPDF.
+
+Outputs one Markdown-formatted .txt file per PDF into the output directory.
+These text files are then used by the agent for synthesis extraction.
+
+Usage:
+    python .agents/skills/mat-synthesis-extraction/scripts/parse_pdfs.py \\
+        --pdf-dir /path/to/pdfs \\
+        --output-dir /path/to/output_texts
+
+Requirements:
+    - Conda environment: base-agent
+    - Required packages: pymupdf
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import fitz  # pymupdf
+
+
+def extract_text_from_pdf(pdf_path: Path) -> str:
+    """
+    Extract text from a PDF file using PyMuPDF.
+
+    Concatenates text from all pages, separated by page markers.
+    Skips pages with no extractable text (e.g. scanned figures).
+
+    Args:
+        pdf_path: Path to the PDF file.
+
+    Returns:
+        Extracted text as a single string.
+    """
+    doc = fitz.open(str(pdf_path))
+    pages = []
+    for page_num, page in enumerate(doc, start=1):
+        text = page.get_text("text").strip()
+        if text:
+            pages.append(f"--- Page {page_num} ---\n{text}")
+    doc.close()
+    return "\n\n".join(pages)
+
+
+def process_pdf_folder(pdf_dir: Path, output_dir: Path) -> list[dict]:
+    """
+    Process all PDF files in a directory and write extracted text to output.
+
+    Args:
+        pdf_dir: Directory containing .pdf files.
+        output_dir: Directory to write extracted .txt files.
+
+    Returns:
+        List of dicts with keys: pdf_name, txt_path, char_count, status.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    pdf_files = sorted(pdf_dir.glob("*.pdf"))
+
+    if not pdf_files:
+        print(f"No PDF files found in {pdf_dir}", file=sys.stderr)
+        return []
+
+    results = []
+    for pdf_path in pdf_files:
+        txt_path = output_dir / (pdf_path.stem + ".txt")
+        text = extract_text_from_pdf(pdf_path)
+
+        if not text.strip():
+            status = "empty"
+            print(f"  [WARN] No text extracted from {pdf_path.name}", file=sys.stderr)
+        else:
+            txt_path.write_text(text, encoding="utf-8")
+            status = "ok"
+            print(f"  [OK] {pdf_path.name} → {txt_path.name} ({len(text)} chars)")
+
+        results.append(
+            {
+                "pdf_name": pdf_path.name,
+                "txt_path": str(txt_path) if status == "ok" else None,
+                "char_count": len(text),
+                "status": status,
+            }
+        )
+
+    summary_path = output_dir / "parse_summary.json"
+    summary_path.write_text(json.dumps(results, indent=2), encoding="utf-8")
+    print(f"\nSummary written to {summary_path}")
+    print(f"Processed {len(results)} PDFs — {sum(r['status'] == 'ok' for r in results)} succeeded.")
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Extract text from a folder of PDFs using PyMuPDF."
+    )
+    parser.add_argument(
+        "--pdf-dir",
+        required=True,
+        type=Path,
+        help="Directory containing input PDF files.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        type=Path,
+        help="Directory to write extracted text files and summary JSON.",
+    )
+    args = parser.parse_args()
+
+    if not args.pdf_dir.exists():
+        print(f"Error: --pdf-dir '{args.pdf_dir}' does not exist.", file=sys.stderr)
+        sys.exit(1)
+
+    process_pdf_folder(args.pdf_dir, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This skill introduces a set of tools to parse paper PDFs and create a set of "structured"* synthesis procedures, as outlined in [LeMat-Synth](https://arxiv.org/abs/2510.26824) and related work. *Structured in this case means adhering to a standardized ontology.
this skill (i) takes in a folder of PDFs (ii) parses each PDF for its synthesis procedures (iii) uses the GeneralSynthesisOntology developed/validated in LeMat-Synth (iv) extracts adhering to this format

This is different from `mat-synthesis-recommendation` since we intend to curate the data rather than suggest new experiments.
Extensions such as LLM-as-a-judge, multimodality, ... can be added.