### PR TITLE
Add mat-epw-mobility skill (QE/EPW phonon-limited mobility and electron-phonon coupling)

### DIFF
--- a/.agents/skills/mat-epw-mobility/SKILL.md
+++ b/.agents/skills/mat-epw-mobility/SKILL.md
@@ -1,0 +1,274 @@
+---
+name: mat-epw-mobility
+description: Compute phonon-limited carrier mobility and mode-resolved electron-phonon coupling in 2D materials from first principles with Quantum ESPRESSO and EPW.
+category: materials
+---
+
+# mat-epw-mobility
+
+## Goal
+To compute the intrinsic phonon-limited carrier mobility $\mu(T)$ of a 2D
+semiconductor in the Self-Energy Relaxation Time Approximation (SERTA), together
+with the mode-resolved electron-phonon coupling matrix elements $|g(k, q, \nu)|$,
+from first principles using the Quantum ESPRESSO + EPW pipeline. The route
+interpolates the electron-phonon vertex onto dense fine grids via maximally
+localized Wannier functions and applies the 2D Frohlich long-range kernel needed
+for polar monolayers.
+
+## Background
+Carrier mobility limited by phonon scattering requires the electron-phonon
+matrix elements $g_{mn\nu}(k, q)$ on grids far denser than any tractable DFPT
+calculation. EPW solves this by computing $g$ on a coarse q-grid with DFPT,
+transforming to a maximally localized Wannier basis, and interpolating to fine
+k/q meshes. For 2D polar materials, the long-range Frohlich part of $g$ diverges
+as $1/q$ near the zone centre and must be treated with a 2D-truncated Coulomb
+kernel (`lpolar`, `system_2d`), otherwise $\mu$ collapses by a factor of ~3.
+
+Unlike the DFT+AMSET route in
+[mat-dft-electronic-transport](../mat-dft-electronic-transport/SKILL.md), which
+uses a momentum-relaxation-time approximation on VASP band structures, this skill
+computes the full first-principles electron-phonon vertex. It is complementary to
+[mat-dft-electron-phonon](../mat-dft-electron-phonon/SKILL.md) (which targets
+temperature-dependent bandgap renormalization) and to
+[mat-phonon](../mat-phonon/SKILL.md) (MLIP phonons).
+
+The pipeline is a DAG. Steps 3 and 5 are optional (a standalone dielectric check
+and a DFPT $|g|$ benchmark); the transport path is 1 -> 2 -> 4 -> 6 -> 7 -> 9.
+
+```
+                       1 SCF
+           +-------------+--------------+
+           v             v              v
+      3 DFPT-Gamma   4 DFPT          2 NSCF
+      (eps_inf, Z*)  uniform-q       (explicit k)
+      (optional)         |               |
+                         v               |
+                    6 pp.py gather       |
+                         |    \          |
+                         |     v         v
+                         |   7 Wannierize
+                         |     |     |
+                         v     v     v
+                    9 EPW    8 EPW  (8 also <- 5 DFPT single-q
+                    SERTA    prtgkk      benchmark, optional)
+                    mu(T)    |g|
+```
+
+The worked example below runs the whole pipeline end-to-end on a ZrS2 monolayer
+and validates EPW-interpolated $|g|$ against the DFPT reference to 0.05% on the
+gauge-invariant sum.
+
+## Instructions
+
+> [!IMPORTANT]
+> Quantum ESPRESSO (`pw.x`, `ph.x`) and EPW (`epw.x`, `pp.py`) are external
+> compiled MPI binaries, exactly as VASP is in
+> [mat-dft-vasp](../mat-dft-vasp/SKILL.md). This skill was validated on a source
+> build of **QE 7.4.1 / EPW 5.8.1** with **ONCV SG15 PBE v1.2** pseudopotentials.
+> The `# Env: base-agent` annotations apply only to the Python parser scripts.
+> Reference input decks for every step are in
+> [`resources/inputs/`](resources/inputs/).
+
+### 1. Ground-state SCF
+Compute the charge density and Kohn-Sham orbitals every later step consumes. For
+2D materials, `assume_isolated = '2D'` truncates the out-of-plane Coulomb tail and
+**must** be mirrored in `ph.x` and EPW. Use the deck
+[`resources/inputs/scf.in`](resources/inputs/scf.in).
+
+```bash
+# Requires: Quantum ESPRESSO 7.4.1 (external MPI build)
+mpirun -np <ranks> pw.x -in scf.in > scf.out
+```
+
+Confirm `convergence has been achieved`. For ZrS2 the total energy is
+-136.1241 Ry and the VBM (HOMO) is -6.4435 eV.
+
+### 2. NSCF on an explicit uniform k-grid
+EPW folds Bloch orbitals on an **explicit** uniform k-grid into Wannier
+functions. Use `K_POINTS crystal` with the full list, never `automatic` (any
+compression desynchronises EPW's k-indexing). Generate the list and stage the
+NSCF into its own `tmp/` so it does not overwrite the SCF save tree that DFPT
+needs. Deck: [`resources/inputs/nscf.in`](resources/inputs/nscf.in).
+
+```bash
+# Env: base-agent
+python .agents/skills/mat-epw-mobility/scripts/gen_kpoints.py 12 12 1
+```
+
+```bash
+# Requires: Quantum ESPRESSO 7.4.1 (external MPI build)
+mpirun -np <ranks> pw.x -in nscf.in > nscf.out
+```
+
+`nbnd` must cover the disentanglement window (30 for ZrS2 = 6 occupied + 24
+empty). For ZrS2 the gap is 1.1724 eV (CBM -5.2711 eV).
+
+### 3. (Optional) Gamma DFPT for dielectric tensor and Born charges
+Compute $\varepsilon_\infty$ and Born effective charges $Z^*$ as a fast
+standalone sanity check (EPW itself reads them from step 4's Gamma irrep). A
+non-symmetric or non-positive-definite $\varepsilon_\infty$ signals an upstream
+error. Deck: [`resources/inputs/ph_gamma.in`](resources/inputs/ph_gamma.in).
+
+```bash
+# Requires: Quantum ESPRESSO 7.4.1 (external MPI build)
+mpirun -np <ranks> ph.x -in ph_gamma.in > ph_gamma.out
+```
+
+For ZrS2: $\varepsilon_\infty^{xx}$ = 2.973, $Z^*_{xx}(\mathrm{Zr})$ = +7.003.
+
+### 4. DFPT on a coarse uniform q-grid
+The dynamical matrices and self-consistent perturbation potentials (`dvscf`) EPW
+interpolates from. This is the most expensive step; set `recover = .true.` so a
+timeout only loses the in-progress q. `fildvscf` is **required** or EPW has no
+long-range kernel data. `nq1/nq2/nq3` must match the coarse `nk*` EPW reads
+later. Deck: [`resources/inputs/ph_uniform.in`](resources/inputs/ph_uniform.in).
+
+```bash
+# Requires: Quantum ESPRESSO 7.4.1 (external MPI build)
+mpirun -np <ranks> ph.x -in ph_uniform.in > ph_uniform.out
+```
+
+For ZrS2 (6x6x1) this yields 7 irreducible q and phonons in 16.9-337.6 cm^-1
+with no imaginary modes.
+
+### 5. (Optional) Single-q DFPT reference for |g|
+The ground-truth $|g(k, q, \nu)|$ at one finite q, against which the EPW
+interpolation (step 8) is benchmarked. **q must not be (0, 0, 0)** (the Frohlich
+cusp diverges); use e.g. crystal (0.005, 0, 0). Stage the NSCF `tmp/` (not SCF)
+so the CBM band is present. Deck:
+[`resources/inputs/ph_single_q.in`](resources/inputs/ph_single_q.in).
+
+```bash
+# Requires: Quantum ESPRESSO 7.4.1 (external MPI build)
+mpirun -np <ranks> ph.x -in ph_single_q.in > ph_q.out
+```
+
+```bash
+# Env: base-agent
+python .agents/skills/mat-epw-mobility/scripts/parse_prt.py ph_q.out --fermi -5.655843
+```
+
+Compare on rank-sorted $|g|$ or the gauge-invariant $\sum |g|^2$ over the
+degenerate LO/TO quartet, never on the raw mode index.
+
+### 6. Gather the EPW save/ tree
+Collect the distributed `dvscf` and `phsave` files from step 4 into the `save/`
+layout EPW expects, using `pp.py` (bundled with EPW). `pp.py` reads the prefix
+from stdin.
+
+```bash
+# Requires: EPW pp.py (bundled with Quantum ESPRESSO 7.4.1)
+printf 'zrs2\n' | python3 pp.py
+```
+
+This produces `save/zrs2.dvscf_q*`, `save/zrs2.dyn_q*`, and `save/zrs2.phsave/`.
+
+### 7. Wannierization (EPW write stage)
+Build maximally localized Wannier functions and write the EPW archive the
+interpolation reads. This is the single strongest predictor of downstream
+quality. **`guiding_centres = .true.` is required** in long-vacuum 2D cells, or WF
+centres fold to a wrong z-image and the total spread explodes ~100x. The
+projections, `nbndsub`, and `exclude_bands` are material-specific. Deck:
+[`resources/inputs/epw_write.in`](resources/inputs/epw_write.in).
+
+```bash
+# Requires: EPW 5.8.1 (external MPI build)
+mpirun -np <ranks> epw.x -npool <ranks> -in epw_write.in > epw_write.out
+```
+
+```bash
+# Env: base-agent
+python .agents/skills/mat-epw-mobility/scripts/parse_wout.py zrs2.wout
+```
+
+`-npool N` with N = ranks is **mandatory** (EPW aborts in < 1 s otherwise). For
+ZrS2, `num_wann` = 9, $\Omega_I$ = 18.5 A^2, $\Omega_{total}/\Omega_I$ ~ 1.05.
+
+### 8. (Optional) Mode-resolved interpolated |g|
+Print EPW-interpolated $|g(k, q, \nu)|$ on an explicit (k, q) list and compare to
+the step-5 DFPT reference. Use explicit `filkf` + `filqf` (not a uniform fine grid
+with an arbitrary q, which aborts in `kpmq_map`). Deck:
+[`resources/inputs/epw_prtgkk.in`](resources/inputs/epw_prtgkk.in).
+
+```bash
+# Requires: EPW 5.8.1 (external MPI build)
+mpirun -np <ranks> epw.x -npool <ranks> -in epw_prtgkk.in > epw_prtgkk.out
+```
+
+```bash
+# Env: base-agent
+python .agents/skills/mat-epw-mobility/scripts/parse_epw_prtgkk.py epw_prtgkk.out --fermi -5.655843
+```
+
+### 9. SERTA carrier mobility
+Compute $\mu(T)$ in the semiconductor SERTA branch on production fine meshes.
+`lpolar = .true.` and `system_2d` must match step 7 exactly. Deck:
+[`resources/inputs/epw_mob.in`](resources/inputs/epw_mob.in).
+
+```bash
+# Requires: EPW 5.8.1 (external MPI build)
+mpirun -np <ranks> epw.x -npool <ranks> -in epw_mob.in > epw_mob.out
+```
+
+Read $\mu_{xx}$ from the last column of `zrs2_elcond_e`. Converge in order of
+impact: `nkf` (= `nqf`) first, then `fsthick` (wide enough to cover the band-edge
+carriers), then `degaussw` (fixed-smearing branch only). For ZrS2 at 1e13 cm^-2
+electron doping and 300 K, $\mu$ lands near 195 cm^2/V/s at a 100x100 fine mesh.
+
+## Examples
+See [`examples/zrs2-monolayer/`](examples/zrs2-monolayer/README.md) for the
+full end-to-end run on a ZrS2 1T monolayer, including expected values at every
+step and the DFPT-vs-EPW $|g|$ validation against the gauge-invariant reference.
+
+## Constraints
+- **External codes**: requires an MPI build of Quantum ESPRESSO 7.4.1 with EPW
+  and Wannier90; the Python parsers run in `base-agent`. Validated with ONCV
+  SG15 PBE v1.2 pseudopotentials. Version pins reflect what was tested, not a
+  claim that other versions are broken.
+- **2D truncation**: `assume_isolated = '2D'` in `pw.x` and `ph.x`, and
+  `lpolar = .true.` with `system_2d` in EPW, must all be set and consistent, or
+  the 2D Frohlich kernel is dropped and $\mu$ collapses by ~3x.
+- **No q = (0, 0, 0)** for electron-phonon coupling in polar 2D systems: the
+  Frohlich $1/q$ cusp diverges. Use q >= (0.005, 0, 0) crystal (steps 5, 8).
+- **`fildvscf` is required** in `ph.x` (steps 4, 5), even for single-q `prt`;
+  omitting it causes a silent MPI abort at high rank count.
+- **`guiding_centres = .true.` is required** for Wannierization in long-vacuum
+  2D cells (step 7).
+- **`-npool N` (N = rank count) is mandatory** for every EPW run.
+- **MPI layout is machine-dependent**: on the validated build, DFT/DFPT ran at
+  `-np 32` (higher counts aborted DFPT silently). If a DFPT or EPW step aborts via
+  MPI with no Fortran trace, re-run at a lower rank count to expose the error.
+- **Material-specific inputs**: `ecutwfc`, `nbnd`, projections, `nbndsub`, and
+  `exclude_bands` are set for ZrS2 in the decks and must be adapted to your
+  material and band manifold.
+- **Gauge invariance**: benchmark $|g|$ on rank-sorted values or
+  $\sum |g|^2$ over the degenerate LO/TO quartet, never on the raw mode index.
+- **Disk**: `etf_mem = 3` checkpoints interpolated $|g|$ to disk; for a
+  100x100 x 100x100 grid this can exceed 100 GB.
+
+## References
+- S. Ponce, E. R. Margine, C. Verdi, F. Giustino, "EPW: Electron-phonon coupling,
+  transport and superconducting properties using maximally localized Wannier
+  functions", *Comput. Phys. Commun.* **209**, 116 (2016).
+  [DOI](https://doi.org/10.1016/j.cpc.2016.07.028)
+- H. Lee, S. Ponce, et al., "Electron-phonon physics from first principles using
+  the EPW code", *npj Comput. Mater.* **9**, 156 (2023).
+  [DOI](https://doi.org/10.1038/s41524-023-01107-3)
+- C. Verdi, F. Giustino, "Frohlich Electron-Phonon Vertex from First Principles",
+  *Phys. Rev. Lett.* **115**, 176401 (2015).
+  [DOI](https://doi.org/10.1103/PhysRevLett.115.176401)
+- T. Sohier, M. Calandra, F. Mauri, "Two-dimensional Frohlich interaction in
+  transition-metal dichalcogenide monolayers: Theoretical modeling and
+  first-principles calculations", *Phys. Rev. B* **94**, 085415 (2016).
+  [DOI](https://doi.org/10.1103/PhysRevB.94.085415)
+- G. Pizzi, et al., "Wannier90 as a community code: new features and
+  applications", *J. Phys. Condens. Matter* **32**, 165902 (2020).
+  [DOI](https://doi.org/10.1088/1361-648X/ab51ff)
+- P. Giannozzi, et al., "Advanced capabilities for materials modelling with
+  Quantum ESPRESSO", *J. Phys. Condens. Matter* **29**, 465901 (2017).
+  [DOI](https://doi.org/10.1088/1361-648X/aa8f79)
+
+---
+
+**Author:** cz2014
+**Contact:** [GitHub @cz2014](https://github.com/cz2014)

--- a/.agents/skills/mat-epw-mobility/SKILL.md
+++ b/.agents/skills/mat-epw-mobility/SKILL.md
@@ -187,7 +187,9 @@ ZrS2, `num_wann` = 9, $\Omega_I$ = 18.5 A^2, $\Omega_{total}/\Omega_I$ ~ 1.05.
 ### 8. (Optional) Mode-resolved interpolated |g|
 Print EPW-interpolated $|g(k, q, \nu)|$ on an explicit (k, q) list and compare to
 the step-5 DFPT reference. Use explicit `filkf` + `filqf` (not a uniform fine grid
-with an arbitrary q, which aborts in `kpmq_map`). Deck:
+with an arbitrary q, which aborts in `kpmq_map`). Note that the coordinate list files
+(`kpoints.dat` and `qpoints.dat`) require a header line specifying coordinate type and count
+(e.g., `1 crystal` followed by coordinate lines), otherwise the Fortran parser fails. Deck:
 [`resources/inputs/epw_prtgkk.in`](resources/inputs/epw_prtgkk.in).
 
 ```bash
@@ -202,8 +204,17 @@ python .agents/skills/mat-epw-mobility/scripts/parse_epw_prtgkk.py epw_prtgkk.ou
 
 ### 9. SERTA carrier mobility
 Compute $\mu(T)$ in the semiconductor SERTA branch on production fine meshes.
-`lpolar = .true.` and `system_2d` must match step 7 exactly. Deck:
-[`resources/inputs/epw_mob.in`](resources/inputs/epw_mob.in).
+`lpolar = .true.` and `system_2d` must match step 7 exactly.
+
+> [!WARNING]
+> Setting `etf_mem = 3` turns on `lfast_kmesh = .true.` to save memory, which
+> **silently bypasses** the standard SERTA drift mobility print statements.
+> For printing the drift mobility table and producing `zrs2_elcond_e`, use `etf_mem = 1`.
+> If you encounter Out-Of-Memory (OOM) errors on large grids, run on a single core
+> (to avoid MPI pool k-point splitting problems) using `etf_mem = 0` and
+> `epmatkqread = .true.` to read pre-computed binary `.epb` files.
+
+Deck: [`resources/inputs/epw_mob.in`](resources/inputs/epw_mob.in).
 
 ```bash
 # Requires: EPW 5.8.1 (external MPI build)

--- a/.agents/skills/mat-epw-mobility/examples/zrs2-monolayer/README.md
+++ b/.agents/skills/mat-epw-mobility/examples/zrs2-monolayer/README.md
@@ -1,0 +1,76 @@
+# Example: ZrS2 1T monolayer
+
+End-to-end run of the `mat-epw-mobility` pipeline on a ZrS2 monolayer (1T
+phase), the system the skill was validated on. It exercises every step, reports
+the expected value at each, and validates the EPW-interpolated electron-phonon
+coupling against the DFPT ground truth.
+
+## System
+
+- ZrS2 1T monolayer, hexagonal, a = 3.669 A, ~30 A vacuum.
+- Structure: [zrs2_monolayer.cif](zrs2_monolayer.cif)
+- Pseudopotentials: ONCV SG15 PBE v1.2 (`Zr_ONCV_PBE-1.2.upf`, `S_ONCV_PBE-1.2.upf`).
+- Validated build: Quantum ESPRESSO 7.4.1 / EPW 5.8.1.
+
+## Goal
+
+1. Cross-validate the EPW Wannier interpolation of $|g(k, q, \nu)|$ against a
+   direct DFPT reference at a finite q (the primary correctness check).
+2. Produce the SERTA phonon-limited electron mobility $\mu(T)$ with the 2D
+   Frohlich kernel enabled.
+
+## Steps
+
+Follow the numbered instructions in [`../../SKILL.md`](../../SKILL.md), using the
+decks in [`../../resources/inputs/`](../../resources/inputs/). The transport path
+is 1 -> 2 -> 4 -> 6 -> 7 -> 9; the $|g|$ validation adds steps 5 and 8.
+
+## Expected values per step
+
+| Step | Quantity | Expected (ZrS2, QE 7.4.1) |
+|---|---|---|
+| 1 SCF | total energy / VBM | -136.1241 Ry / -6.4435 eV |
+| 2 NSCF | gap (CBM) | 1.1724 eV (CBM -5.2711 eV) |
+| 3 DFPT-Gamma | $\varepsilon_\infty^{xx}$ / $Z^*_{xx}(\mathrm{Zr})$ | 2.973 / +7.003 |
+| 4 DFPT uniform-q | irreducible q / phonon range | 7 / 16.9-337.6 cm^-1 (no imaginary) |
+| 7 Wannierize | `num_wann` / $\Omega_I$ / $\Omega_{total}/\Omega_I$ | 9 / 18.5 A^2 / ~1.05 |
+| 9 SERTA | $\mu_{xx}$ (100x100 mesh, 300 K, 1e13 cm^-2) | ~195 cm^2/V/s |
+
+## Primary validation: EPW-interpolated |g| vs DFPT reference
+
+At k = M, q = (0.005, 0, 0) crystal, comparing the DFPT reference (step 5,
+`parse_prt.py`) to the EPW Wannier interpolation (step 8, `parse_epw_prtgkk.py`):
+
+| Metric | Step 5 (DFPT) | Step 8 (EPW) | Difference |
+|---|---|---|---|
+| Rank-1 $\|g\|$ | 1909.7 meV | 1941.6 meV | 1.67 % |
+| $\sum \|g\|^2$ over top-4 $\omega$ modes | 8744.0 meV^2 | 8748.7 meV^2 | 0.054 % |
+
+The 1.67 % rank-1 offset is a gauge rotation within the near-degenerate LO/TO
+subspace (the two modes lie within ~0.1 meV). The gauge-invariant sum
+$\sum |g|^2$ agrees to **0.054 %**, confirming that the Wannier interpolation
+reproduces the DFPT electron-phonon vertex. Validation passes on the
+gauge-invariant sum, not on the raw per-mode value.
+
+## Literature context for the mobility
+
+Published deformation-potential-theory (DPT) studies report an electron mobility
+of order $\sim 1.2 \times 10^3$ cm^2/V/s for ZrS2 monolayer at 300 K (roughly 4x
+that of monolayer MoS2). The SERTA value here (~195 cm^2/V/s) is deliberately
+lower and **not directly comparable**: DPT accounts only for acoustic
+deformation-potential scattering, whereas this pipeline includes the polar-optical
+(2D Frohlich) scattering that dominates in polar monolayers and strongly
+suppresses $\mu$ (see Verdi & Giustino 2015 and Sohier, Calandra & Mauri 2016 in
+[`../../SKILL.md`](../../SKILL.md#references)). A like-for-like literature
+comparison must match the scattering model, the transport equation (SERTA vs
+iterative BTE), and the carrier density. The rigorous correctness check for this
+skill is therefore the DFPT-vs-EPW $|g|$ benchmark above, which isolates the
+electron-phonon machinery from those modelling choices.
+
+> [!NOTE]
+> Artifacts (`.save` trees, `dvscf`, checkpoints) are not committed here; a full
+> production run of step 9 can write >100 GB of interpolated `|g|` to disk.
+
+## 3D Structures
+
+- [zrs2_monolayer.cif](zrs2_monolayer.cif) — ZrS2 1T monolayer primitive cell.

--- a/.agents/skills/mat-epw-mobility/examples/zrs2-monolayer/zrs2_monolayer.cif
+++ b/.agents/skills/mat-epw-mobility/examples/zrs2-monolayer/zrs2_monolayer.cif
@@ -1,0 +1,21 @@
+data_ZrS2_monolayer_1T
+_cell_length_a      3.66900
+_cell_length_b      3.66900
+_cell_length_c     30.00000
+_cell_angle_alpha  90.0
+_cell_angle_beta   90.0
+_cell_angle_gamma 120.0
+_symmetry_space_group_name_H-M   'P 1'
+_symmetry_Int_Tables_number      1
+loop_
+  _symmetry_equiv_pos_as_xyz
+  'x, y, z'
+loop_
+  _atom_site_label
+  _atom_site_type_symbol
+  _atom_site_fract_x
+  _atom_site_fract_y
+  _atom_site_fract_z
+  Zr1 Zr 0.000000 0.000000 0.500000
+  S1  S  0.333333 0.666667 0.548302
+  S2  S  0.666667 0.333333 0.451698

--- a/.agents/skills/mat-epw-mobility/resources/inputs/epw_mob.in
+++ b/.agents/skills/mat-epw-mobility/resources/inputs/epw_mob.in
@@ -1,0 +1,42 @@
+&inputepw
+  prefix      = 'zrs2'
+  outdir      = '../02_nscf_out/tmp'       ! NSCF save tree (step 2)
+  dvscf_dir   = '../04_dfpt_out/tmp/save'  ! save/ from step 6
+  amass(1)    = 91.224
+  amass(2)    = 32.065
+
+  ! Restart from the Wannier archive (step 7)
+  elph        = .true.
+  epwwrite    = .false.
+  epwread     = .true.
+  wannierize  = .false.
+
+  lpolar      = .true.
+  vme         = 'wannier'
+  system_2d   = 'gaussian'                 ! must match step 7
+
+  ! SERTA transport branch
+  scattering    = .true.
+  carrier       = .true.
+  ncarrier      = 1.0E13                   ! electrons; EPW sign convention: + = e
+  assume_metal  = .false.
+
+  nstemp        = 1
+  temps         = 300.0                    ! K
+
+  fsthick       = 4.0                      ! eV; broad window, adaptive smearing
+  degaussw      = 0.0                      ! 0 => adaptive smearing
+  efermi_read   = .true.
+  fermi_energy  = -5.655843                ! eV; from step 1 shifted for doping
+
+  mp_mesh_k     = .true.
+  etf_mem       = 3                        ! checkpoint mode for large fine meshes
+
+  nbndsub       = 9
+  bands_skipped = 'exclude_bands = 1-6,16-30'
+
+  nk1 = 12, nk2 = 12, nk3 = 1              ! match NSCF / step 4 / step 7
+  nq1 = 6,  nq2 = 6,  nq3 = 1
+  nkf1 = 60, nkf2 = 60, nkf3 = 1           ! production fine k-mesh
+  nqf1 = 60, nqf2 = 60, nqf3 = 1           ! production fine q-mesh
+/

--- a/.agents/skills/mat-epw-mobility/resources/inputs/epw_mob.in
+++ b/.agents/skills/mat-epw-mobility/resources/inputs/epw_mob.in
@@ -30,7 +30,7 @@
   fermi_energy  = -5.655843                ! eV; from step 1 shifted for doping
 
   mp_mesh_k     = .true.
-  etf_mem       = 3                        ! checkpoint mode for large fine meshes
+  etf_mem       = 1                        ! 1 (or 0) for standard SERTA; 3 (lfast_kmesh) skips SERTA output
 
   nbndsub       = 9
   bands_skipped = 'exclude_bands = 1-6,16-30'

--- a/.agents/skills/mat-epw-mobility/resources/inputs/epw_prtgkk.in
+++ b/.agents/skills/mat-epw-mobility/resources/inputs/epw_prtgkk.in
@@ -1,0 +1,34 @@
+&inputepw
+  prefix      = 'zrs2'
+  outdir      = '../02_nscf_out/tmp'       ! NSCF save tree (step 2)
+  dvscf_dir   = '../04_dfpt_out/tmp/save'  ! save/ from step 6
+  amass(1)    = 91.224
+  amass(2)    = 32.065
+
+  ! Restart from the Wannier archive (step 7)
+  elph        = .true.
+  epwwrite    = .false.
+  epwread     = .true.
+  wannierize  = .false.
+  prtgkk      = .true.                     ! ENABLE |g| printing
+
+  lpolar      = .true.
+  vme         = 'wannier'
+  system_2d   = 'gaussian'                 ! must match step 7
+
+  ! No transport kernel - we only want |g| printed on the explicit (k, q)
+  scattering  = .false.
+  nstemp      = 1
+  temps       = 300
+  fsthick     = 4.0
+  degaussw    = 0.025
+
+  nbndsub       = 9
+  bands_skipped = 'exclude_bands = 1-6,16-30'
+
+  nk1 = 12, nk2 = 12, nk3 = 1              ! match NSCF / step 4 / step 7
+  nq1 = 6,  nq2 = 6,  nq3 = 1
+
+  filkf = 'kpoints.dat'                    ! explicit k-list
+  filqf = 'qpoints.dat'                    ! explicit q-list (NOT 0,0,0)
+/

--- a/.agents/skills/mat-epw-mobility/resources/inputs/epw_write.in
+++ b/.agents/skills/mat-epw-mobility/resources/inputs/epw_write.in
@@ -1,0 +1,40 @@
+&inputepw
+  prefix    = 'zrs2'
+  outdir    = '../02_nscf_out/tmp'       ! NSCF save tree (step 2)
+  dvscf_dir = '../04_dfpt_out/tmp/save'  ! save/ from step 6
+
+  elph      = .true.
+  epbwrite  = .true.
+  epbread   = .false.
+  epwwrite  = .true.
+  epwread   = .false.
+
+  lpolar    = .true.                     ! enable 2D Frohlich long range
+  vme       = 'wannier'
+  system_2d = 'gaussian'                 ! or 'dipole_sh' - pick one, keep it
+
+  nbndsub       = 9                      ! material-specific; span your manifold
+  bands_skipped = 'exclude_bands = 1-6,16-30'
+
+  wannierize = .true.
+  num_iter   = 20000
+  iprint     = 2
+  proj(1)    = 'S:p'
+  proj(2)    = 'Zr:dz2;dxy;dx2-y2'
+
+  wdata(1)  = 'guiding_centres=.true.'   ! CRITICAL in 2D long-vacuum cells
+  wdata(2)  = 'conv_tol=1E-12'
+  wdata(3)  = 'conv_window=5'
+  wdata(4)  = 'bands_plot=.true.'
+  wdata(5)  = 'bands_num_points=100'
+  wdata(6)  = 'begin kpoint_path'
+  wdata(7)  = 'G 0.000 0.000 0.000 M 0.500 0.000 0.000'
+  wdata(8)  = 'M 0.500 0.000 0.000 K 0.333333 0.333333 0.000'
+  wdata(9)  = 'K 0.333333 0.333333 0.000 G 0.000 0.000 0.000'
+  wdata(10) = 'end kpoint_path'
+
+  nk1 = 12, nk2 = 12, nk3 = 1            ! match NSCF / step 4
+  nq1 = 6,  nq2 = 6,  nq3 = 1
+  nkf1 = 20, nkf2 = 20, nkf3 = 1         ! fine grid for the band-gate check
+  nqf1 = 20, nqf2 = 20, nqf3 = 1
+/

--- a/.agents/skills/mat-epw-mobility/resources/inputs/nscf.in
+++ b/.agents/skills/mat-epw-mobility/resources/inputs/nscf.in
@@ -1,0 +1,36 @@
+&control
+  calculation = 'nscf'
+  prefix      = 'zrs2'
+  outdir      = './tmp'
+  pseudo_dir  = './pp'
+  verbosity   = 'high'
+/
+&system
+  ibrav           = 4
+  celldm(1)       = 6.93340465
+  celldm(3)       = 8.17661488
+  nat             = 3
+  ntyp            = 2
+  ecutwfc         = 60.0
+  nbnd            = 30                  ! >= VBM + CBM + disentanglement window
+  occupations     = 'fixed'
+  assume_isolated = '2D'
+/
+&electrons
+  conv_thr        = 1.0d-10
+  diago_full_acc  = .true.             ! optional; tight empty-band convergence
+  diagonalization = 'david'
+  mixing_beta     = 0.7
+/
+ATOMIC_SPECIES
+  Zr  91.224   Zr_ONCV_PBE-1.2.upf
+  S   32.065   S_ONCV_PBE-1.2.upf
+ATOMIC_POSITIONS crystal
+  Zr  0.000000000   0.000000000   0.500000000
+  S   0.333333000   0.666667000   0.548302181
+  S   0.666667000   0.333333000   0.451697819
+K_POINTS crystal
+144
+! Generate the explicit 12x12x1 list with:
+!   python scripts/gen_kpoints.py 12 12 1
+! Paste the 144 points (fractional, unit weight) here, replacing this comment.

--- a/.agents/skills/mat-epw-mobility/resources/inputs/ph_gamma.in
+++ b/.agents/skills/mat-epw-mobility/resources/inputs/ph_gamma.in
@@ -1,0 +1,11 @@
+Epsilon and Z* at Gamma (ZrS2 monolayer, 2D slab)
+&inputph
+  prefix     = 'zrs2'
+  outdir     = './tmp'
+  fildyn     = 'dyn_q0'
+  tr2_ph     = 1.0d-14             ! monolayer; 1.0d-12 for bilayer/thicker
+  ldisp      = .false.
+  epsil      = .true.             ! high-frequency dielectric tensor
+  zeu        = .true.             ! Born effective charges
+/
+0.0 0.0 0.0

--- a/.agents/skills/mat-epw-mobility/resources/inputs/ph_single_q.in
+++ b/.agents/skills/mat-epw-mobility/resources/inputs/ph_single_q.in
@@ -1,0 +1,17 @@
+EPC at q=(0.005,0,0) crystal -> Cartesian (0.005, 0.0028867513, 0)
+&inputph
+  prefix           = 'zrs2'
+  outdir           = './tmp'
+  fildyn           = 'dyn_q0.005'
+  fildvscf         = 'dvscf_q0.005'      ! REQUIRED even for single-q prt
+  tr2_ph           = 1.0d-14
+  ldisp            = .false.
+  trans            = .true.
+  electron_phonon  = 'prt'                ! QE 7.4.1; legacy 'simple' is gone
+  kx               = 0.5
+  ky               = 0.288675134594813    ! K in Cartesian 2pi/a
+  kz               = 0.0
+  nk1 = 12, nk2 = 12, nk3 = 1             ! match SCF k-grid
+  k1  = 0,  k2  = 0,  k3  = 0
+/
+0.0050000000  0.0028867513  0.0           ! q in Cartesian 2pi/a (never 0,0,0)

--- a/.agents/skills/mat-epw-mobility/resources/inputs/ph_uniform.in
+++ b/.agents/skills/mat-epw-mobility/resources/inputs/ph_uniform.in
@@ -1,0 +1,15 @@
+Phonon calculation for monolayer ZrS2 (6x6x1 uniform q)
+&inputph
+  prefix    = 'zrs2'
+  outdir    = './tmp'
+  fildyn    = 'zrs2.dyn'
+  fildvscf  = 'dvscf'              ! REQUIRED for the EPW long-range kernel
+  tr2_ph    = 1.0d-14
+  ldisp     = .true.
+  nq1       = 6
+  nq2       = 6
+  nq3       = 1                    ! 2D: always 1
+  epsil     = .true.
+  zeu       = .true.
+  recover   = .true.              ! restart on timeout; only loses in-progress q
+/

--- a/.agents/skills/mat-epw-mobility/resources/inputs/scf.in
+++ b/.agents/skills/mat-epw-mobility/resources/inputs/scf.in
@@ -1,0 +1,31 @@
+&control
+  calculation = 'scf'
+  prefix      = 'zrs2'
+  outdir      = './tmp'
+  pseudo_dir  = './pp'
+  tprnfor     = .true.
+  tstress     = .true.
+/
+&system
+  ibrav           = 4               ! hexagonal; set to match your Bravais lattice
+  celldm(1)       = 6.93340465      ! Bohr, in-plane
+  celldm(3)       = 8.17661488      ! c/a; ~30 A vacuum on a ~3 A slab
+  nat             = 3
+  ntyp            = 2
+  ecutwfc         = 60.0            ! material-specific; EPC-converged for ZrS2
+  occupations     = 'fixed'         ! semiconductor, no smearing
+  assume_isolated = '2D'            ! REQUIRED; mirror in ph.x and EPW
+/
+&electrons
+  conv_thr    = 1.0d-10
+  mixing_beta = 0.7
+/
+ATOMIC_SPECIES
+  Zr  91.224   Zr_ONCV_PBE-1.2.upf
+  S   32.065   S_ONCV_PBE-1.2.upf
+ATOMIC_POSITIONS crystal
+  Zr  0.000000000   0.000000000   0.500000000
+  S   0.333333000   0.666667000   0.548302181
+  S   0.666667000   0.333333000   0.451697819
+K_POINTS automatic
+  12 12 1  0 0 0

--- a/.agents/skills/mat-epw-mobility/scripts/compare_reference.py
+++ b/.agents/skills/mat-epw-mobility/scripts/compare_reference.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Print a reference-vs-measured comparison table for two JSON files.
+
+Loads a reference JSON (expected values) and a measured JSON (parser output),
+and prints a ``field | reference | measured | delta`` table. It makes no
+assertions: the reviewer or agent judges whether each delta is acceptable, as
+tolerances here are physical (gauge rotations, mesh convergence), not exact.
+
+Usage:
+    python compare_reference.py reference.json measured.json
+
+Requirements:
+    - Conda environment: base-agent
+    - Required packages: none (Python standard library only)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def delta(reference: object, measured: object) -> str:
+    """Compute ``measured - reference`` for numeric fields, else ``-``.
+
+    Args:
+        reference: Reference value for a field.
+        measured: Measured value for a field.
+
+    Returns:
+        Signed difference formatted to 6 significant figures, or ``-`` when
+        either value is non-numeric.
+    """
+    try:
+        return f"{float(measured) - float(reference):+.6g}"  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return "-"
+
+
+def main() -> None:
+    """Command-line entry point."""
+    parser = argparse.ArgumentParser(
+        description="Print a reference-vs-measured comparison table for two JSON files."
+    )
+    parser.add_argument("reference", help="Path to reference.json (expected values)")
+    parser.add_argument("measured", help="Path to measured.json (parser output)")
+    args = parser.parse_args()
+
+    ref = json.loads(Path(args.reference).read_text() or "{}")
+    measured = json.loads(Path(args.measured).read_text() or "{}")
+
+    print(f"{'field':<35} {'reference':>18} {'measured':>18} {'delta':>12}")
+    for key in sorted(set(ref) | set(measured)):
+        r, mv = ref.get(key, "-"), measured.get(key, "-")
+        print(f"{key:<35} {str(r):>18} {str(mv):>18} {delta(r, mv):>12}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/mat-epw-mobility/scripts/gen_kpoints.py
+++ b/.agents/skills/mat-epw-mobility/scripts/gen_kpoints.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Generate an explicit uniform k-point list for a QE NSCF ``K_POINTS crystal`` card.
+
+EPW reads back the full uniform mesh, so the NSCF must use an explicit k-list
+(``K_POINTS crystal``), never ``automatic`` (step 2). This prints the header
+line and the ``n1 * n2 * n3`` fractional points with unit weights, ready to
+paste into ``nscf.in``.
+
+Usage:
+    python gen_kpoints.py 12 12 1
+
+Requirements:
+    - Conda environment: base-agent
+    - Required packages: none (Python standard library only)
+"""
+
+from __future__ import annotations
+
+import argparse
+
+
+def uniform_kpoints(n1: int, n2: int, n3: int) -> list[tuple[float, float, float]]:
+    """Build the fractional coordinates of a uniform Gamma-centred mesh.
+
+    Args:
+        n1: Number of divisions along b1.
+        n2: Number of divisions along b2.
+        n3: Number of divisions along b3 (use 1 for a 2D slab).
+
+    Returns:
+        List of (k1, k2, k3) fractional coordinates.
+    """
+    return [
+        (i / n1, j / n2, k / n3)
+        for i in range(n1)
+        for j in range(n2)
+        for k in range(n3)
+    ]
+
+
+def format_card(points: list[tuple[float, float, float]]) -> str:
+    """Format a k-point list as a QE ``K_POINTS crystal`` card.
+
+    Args:
+        points: Fractional coordinates from :func:`uniform_kpoints`.
+
+    Returns:
+        The card text, including the ``K_POINTS crystal`` header and count line.
+    """
+    lines = ["K_POINTS crystal", str(len(points))]
+    lines += [f"{a:.10f}  {b:.10f}  {c:.10f}  1.0" for a, b, c in points]
+    return "\n".join(lines)
+
+
+def main() -> None:
+    """Command-line entry point."""
+    parser = argparse.ArgumentParser(
+        description="Generate an explicit uniform K_POINTS crystal card for QE NSCF."
+    )
+    parser.add_argument("n1", type=int, help="Divisions along b1")
+    parser.add_argument("n2", type=int, help="Divisions along b2")
+    parser.add_argument("n3", type=int, help="Divisions along b3 (1 for a 2D slab)")
+    args = parser.parse_args()
+
+    print(format_card(uniform_kpoints(args.n1, args.n2, args.n3)))
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/mat-epw-mobility/scripts/parse_epw_prtgkk.py
+++ b/.agents/skills/mat-epw-mobility/scripts/parse_epw_prtgkk.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Parse EPW ``prtgkk`` output into JSON.
+
+Reads the Wannier-interpolated electron-phonon matrix elements |g(k, q, nu)|
+printed by EPW (step 8). The table rows share the ph.x prt schema; only the
+q/k header format differs. For the diagonal (ibnd == jbnd) band closest to the
+Fermi level (the CBM), it reports the rank-1 |g| and the gauge-invariant sum of
+|g|^2 over the four highest-omega modes, so the interpolated values can be
+compared directly against the step-5 DFPT reference.
+
+Usage:
+    python parse_epw_prtgkk.py <epw.out> [--fermi <eV>]
+
+Requirements:
+    - Conda environment: base-agent
+    - Required packages: none (Python standard library only)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import defaultdict
+
+ROW_RE = re.compile(
+    r"^\s*(\d+)\s+(\d+)\s+(\d+)\s+([-\d.Ee+]+)\s+([-\d.Ee+]+)\s+([-\d.Ee+]+)\s+([-\d.Ee+]+)\s*$",
+    re.MULTILINE,
+)
+
+
+def parse_rows(text: str) -> list[dict]:
+    """Extract the |g| table rows from an EPW prtgkk output.
+
+    Args:
+        text: Full contents of the EPW output file.
+
+    Returns:
+        List of row dictionaries with keys ibnd, jbnd, imode, enk, enkq,
+        omega_meV, g_meV.
+    """
+    rows: list[dict] = []
+    for m in ROW_RE.finditer(text):
+        rows.append(
+            {
+                "ibnd": int(m.group(1)),
+                "jbnd": int(m.group(2)),
+                "imode": int(m.group(3)),
+                "enk": float(m.group(4)),
+                "enkq": float(m.group(5)),
+                "omega_meV": float(m.group(6)),
+                "g_meV": float(m.group(7)),
+            }
+        )
+    return rows
+
+
+def summarize(text: str, fermi: float, n_modes: int = 9) -> dict:
+    """Summarize the CBM electron-phonon coupling from an EPW prtgkk output.
+
+    Args:
+        text: Full contents of the EPW output file.
+        fermi: Fermi energy in eV used to select the CBM band.
+        n_modes: Number of phonon modes per (k, q) block (3 * natoms).
+
+    Returns:
+        Dictionary with the q coordinate, the rank-1 |g| and mode, and the
+        gauge-invariant sum of |g|^2 over the four highest-omega modes.
+    """
+    q = re.search(r"iq\s*=\s*\d+\s+coord\.:\s+([-\d.]+)\s+([-\d.]+)\s+([-\d.]+)", text)
+    rows = parse_rows(text)
+
+    result: dict = {
+        "q_cartesian": [float(q.group(i)) for i in (1, 2, 3)] if q else None,
+        "fermi_eV_used": fermi,
+        "n_rows": len(rows),
+    }
+
+    by_ibnd: dict[int, list[dict]] = defaultdict(list)
+    for r in rows:
+        if r["ibnd"] == r["jbnd"]:
+            by_ibnd[r["ibnd"]].append(r)
+    if by_ibnd:
+        cbm = min(by_ibnd, key=lambda b: abs(by_ibnd[b][0]["enk"] - fermi))
+        block = sorted(by_ibnd[cbm][:n_modes], key=lambda r: r["imode"])
+        gs = [r["g_meV"] for r in block]
+        om = [r["omega_meV"] for r in block]
+        imax = max(range(len(gs)), key=lambda i: gs[i])
+        top4 = sorted(range(len(om)), key=lambda i: om[i], reverse=True)[:4]
+        result["cbm_ibnd"] = cbm
+        result["cbm_enk_eV"] = block[0]["enk"]
+        result["rank1_mode_index"] = block[imax]["imode"]
+        result["rank1_omega_meV"] = om[imax]
+        result["rank1_g_meV"] = gs[imax]
+        result["sum_g2_LO_TO_quartet_meV2"] = sum(gs[i] ** 2 for i in top4)
+    return result
+
+
+def main() -> None:
+    """Command-line entry point."""
+    parser = argparse.ArgumentParser(description="Parse EPW prtgkk output into JSON.")
+    parser.add_argument("epw_out", help="Path to the EPW prtgkk output file")
+    parser.add_argument(
+        "--fermi",
+        type=float,
+        default=-5.655843,
+        help="Fermi energy in eV used to select the CBM band (default: ZrS2 value)",
+    )
+    parser.add_argument(
+        "--n-modes",
+        type=int,
+        default=9,
+        help="Number of phonon modes per (k, q) block, i.e. 3 * natoms (default: 9)",
+    )
+    args = parser.parse_args()
+
+    with open(args.epw_out) as fh:
+        text = fh.read()
+    print(json.dumps(summarize(text, args.fermi, args.n_modes), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/mat-epw-mobility/scripts/parse_prt.py
+++ b/.agents/skills/mat-epw-mobility/scripts/parse_prt.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Parse ph.x ``electron_phonon='prt'`` output into JSON.
+
+Reads the reference electron-phonon matrix elements |g(k, q, nu)| printed by a
+single-q DFPT run (step 5). For the diagonal (ibnd == jbnd) band whose energy
+is closest to the Fermi level (treated as the conduction-band minimum), it
+reports the rank-1 |g| and the gauge-invariant sum over the four highest-omega
+(LO/TO) modes. The gauge-invariant sum is the quantity to benchmark against,
+not the raw per-mode value.
+
+Usage:
+    python parse_prt.py <ph.out> [--fermi <eV>]
+
+Requirements:
+    - Conda environment: base-agent
+    - Required packages: none (Python standard library only)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import defaultdict
+
+ROW_RE = re.compile(
+    r"^\s*(\d+)\s+(\d+)\s+(\d+)\s+([-\d.Ee+]+)\s+([-\d.Ee+]+)\s+([-\d.Ee+]+)\s+([-\d.Ee+]+)\s*$",
+    re.MULTILINE,
+)
+
+
+def parse_rows(text: str) -> list[dict]:
+    """Extract the |g| table rows from a ph.x prt output.
+
+    Args:
+        text: Full contents of the ph.x output file.
+
+    Returns:
+        List of row dictionaries with keys ibnd, jbnd, imode, enk, enkq,
+        omega_meV, g_meV.
+    """
+    rows: list[dict] = []
+    for m in ROW_RE.finditer(text):
+        rows.append(
+            {
+                "ibnd": int(m.group(1)),
+                "jbnd": int(m.group(2)),
+                "imode": int(m.group(3)),
+                "enk": float(m.group(4)),
+                "enkq": float(m.group(5)),
+                "omega_meV": float(m.group(6)),
+                "g_meV": float(m.group(7)),
+            }
+        )
+    return rows
+
+
+def summarize(text: str, fermi: float) -> dict:
+    """Summarize the CBM electron-phonon coupling from a ph.x prt output.
+
+    Args:
+        text: Full contents of the ph.x output file.
+        fermi: Fermi energy in eV used to select the CBM band.
+
+    Returns:
+        Dictionary with the q/k coordinates, the rank-1 |g| and mode, and the
+        gauge-invariant sum of |g|^2 over the four highest-omega modes.
+    """
+    q = re.search(r"q coord\.:\s+([-\d.]+)\s+([-\d.]+)\s+([-\d.]+)", text)
+    k = re.search(r"k coord\.:\s+([-\d.]+)\s+([-\d.]+)\s+([-\d.]+)", text)
+    rows = parse_rows(text)
+
+    result: dict = {
+        "q_cartesian": [float(q.group(i)) for i in (1, 2, 3)] if q else None,
+        "k_cartesian": [float(k.group(i)) for i in (1, 2, 3)] if k else None,
+        "fermi_eV_used": fermi,
+        "n_rows": len(rows),
+    }
+
+    diag: dict[int, list[dict]] = defaultdict(list)
+    for r in rows:
+        if r["ibnd"] == r["jbnd"]:
+            diag[r["ibnd"]].append(r)
+    if diag:
+        cbm = min(diag, key=lambda b: abs(diag[b][0]["enk"] - fermi))
+        block = sorted(diag[cbm], key=lambda r: r["imode"])
+        gs = [r["g_meV"] for r in block]
+        om = [r["omega_meV"] for r in block]
+        imax = max(range(len(gs)), key=lambda i: gs[i])
+        top4 = sorted(range(len(om)), key=lambda i: om[i], reverse=True)[:4]
+        result["cbm_ibnd"] = cbm
+        result["cbm_enk_eV"] = block[0]["enk"]
+        result["rank1_mode_index"] = block[imax]["imode"]
+        result["rank1_omega_meV"] = om[imax]
+        result["rank1_g_meV"] = gs[imax]
+        result["sum_g2_LO_TO_quartet_meV2"] = sum(gs[i] ** 2 for i in top4)
+    return result
+
+
+def main() -> None:
+    """Command-line entry point."""
+    parser = argparse.ArgumentParser(
+        description="Parse ph.x electron_phonon='prt' output into JSON."
+    )
+    parser.add_argument("ph_out", help="Path to the ph.x prt output file")
+    parser.add_argument(
+        "--fermi",
+        type=float,
+        default=-5.655843,
+        help="Fermi energy in eV used to select the CBM band (default: ZrS2 value)",
+    )
+    args = parser.parse_args()
+
+    with open(args.ph_out) as fh:
+        text = fh.read()
+    print(json.dumps(summarize(text, args.fermi), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/mat-epw-mobility/scripts/parse_wout.py
+++ b/.agents/skills/mat-epw-mobility/scripts/parse_wout.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Parse a Wannier90 ``.wout`` Final State block into JSON.
+
+Extracts the maximally-localized Wannier function (MLWF) spread decomposition
+and centres from the last ``Final State`` block. This is the primary quality
+gate for the Wannier stage (step 7): a total spread that is large relative to
+the gauge-invariant lower bound Omega_I signals image folding in a long-vacuum
+2D cell.
+
+Usage:
+    python parse_wout.py <prefix.wout>
+
+Requirements:
+    - Conda environment: base-agent
+    - Required packages: none (Python standard library only)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+
+
+def parse_wout(text: str) -> dict:
+    """Parse the final ``Final State`` block of a Wannier90 ``.wout`` file.
+
+    Args:
+        text: Full contents of the ``.wout`` file.
+
+    Returns:
+        Dictionary with the spread decomposition (omega_I_A2, omega_D_A2,
+        omega_OD_A2, omega_total_A2), the per-WF centres (wf_centres_xyz_A) and
+        spreads (wf_spreads_A2), and the z-range of the centres
+        (wf_centres_z_min, wf_centres_z_max) used as an image-folding check.
+    """
+    block_starts = [
+        m.start() for m in re.finditer(r"^\s*Final State\s*$", text, re.MULTILINE)
+    ]
+    tail = text[block_starts[-1] :] if block_starts else text
+
+    centres: list[list[float]] = []
+    spreads: list[float] = []
+    for m in re.finditer(
+        r"WF centre and spread\s+\d+\s*\(\s*([-\d.]+),\s*([-\d.]+),\s*([-\d.]+)\s*\)\s+([-\d.]+)",
+        tail,
+    ):
+        centres.append([float(m.group(i)) for i in (1, 2, 3)])
+        spreads.append(float(m.group(4)))
+
+    def grab(label: str) -> float | None:
+        m = re.search(rf"Omega\s+{label}\s*=\s*([-\d.Ee+]+)", tail)
+        return float(m.group(1)) if m else None
+
+    result: dict = {
+        "omega_I_A2": grab("I"),
+        "omega_D_A2": grab("D"),
+        "omega_OD_A2": grab("OD"),
+        "omega_total_A2": grab("Total"),
+        "wf_centres_xyz_A": centres,
+        "wf_spreads_A2": spreads,
+    }
+    if centres:
+        zs = [c[2] for c in centres]
+        result["wf_centres_z_min"] = min(zs)
+        result["wf_centres_z_max"] = max(zs)
+    return result
+
+
+def main() -> None:
+    """Command-line entry point."""
+    parser = argparse.ArgumentParser(
+        description="Parse a Wannier90 .wout Final State block into JSON."
+    )
+    parser.add_argument("wout", help="Path to the Wannier90 .wout file")
+    args = parser.parse_args()
+
+    with open(args.wout) as fh:
+        text = fh.read()
+    print(json.dumps(parse_wout(text), indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds `mat-epw-mobility`, a `materials` skill that computes phonon-limited carrier
mobility (SERTA) and mode-resolved electron-phonon coupling |g(k, q, nu)| for 2D
materials via the first-principles **Quantum ESPRESSO + EPW + Wannier90** route
(SCF -> NSCF -> DFPT -> Wannier -> EPW).

## Why it is complementary

- `mat-dft-electronic-transport` computes mobility via VASP + AMSET (a
  momentum-relaxation-time approximation).
- `mat-dft-electron-phonon` computes temperature-dependent bandgap renormalization.

This skill adds the first-principles EPW electron-phonon vertex with the 2D
Frohlich long-range kernel, and extracts mode-resolved |g| — neither of which the
existing skills provide. It cross-links to all three.

## Form

QE/EPW/Wannier90 are external compiled MPI binaries, handled the same way VASP is
in `mat-dft-vasp` (prepare inputs, run, parse outputs). No new MCP tool or conda
environment is introduced; the Python parsers run in `base-agent`. This is the
first Quantum ESPRESSO-based skill in the repo, so I am happy to adjust naming or
structure to your preference.

## Standard compliance

- Single `SKILL.md` (Goal / Background / Instructions 1-9 / Examples / Constraints
  / References / human author footer).
- `scripts/` are ruff-clean with argparse, type hints, and docstrings.
- `resources/inputs/` holds the concrete input decks; `examples/zrs2-monolayer/`
  has per-step expected values, a linked CIF for the 3D viewer, and a DFPT-vs-EPW
  |g| validation (0.05% on the gauge-invariant sum). Literature mobility is
  discussed as caveated context, since published ZrS2 values are
  deformation-potential estimates that omit the polar-optical scattering this
  route includes.
- Pre-commit (ruff, ruff-format, check-yaml, trailing-whitespace, end-of-file)
  passes.

## Validation

Validated end-to-end on a ZrS2 1T monolayer with QE 7.4.1 / EPW 5.8.1 and ONCV
SG15 PBE v1.2 pseudopotentials.
