### PR TITLE
fix(mat-elasticity): default to relaxed-ion, split the two force thresholds

### DIFF
--- a/.agents/skills/mat-elasticity/SKILL.md
+++ b/.agents/skills/mat-elasticity/SKILL.md
@@ -52,7 +52,7 @@ python .agents/skills/mat-elasticity/scripts/calculate_elasticity.py \
 - `--norm_strains`: Normal strain magnitudes applied (default: ±0.5%, ±1.0%)
 - `--shear_strains`: Shear strain magnitudes applied (default: ±3%, ±6%)
 - `--relax_structure`: Relax the structure before applying strains (recommended)
-- `--relax_deformed`: Additionally relax atomic positions in each deformed structure (usually not needed)
+- `--relax_deformed` / `--no-relax_deformed` (**default on**): re-minimise the ions inside each deformed cell, with the cell held fixed. See **Relaxed-ion versus clamped-ion** below — this flag selects which of two physically distinct quantities you get, and the difference is not small.
 - `--fmax`: Force convergence tolerance for relaxation (default: 0.1 eV/Å)
 
 > [!TIP]
@@ -89,10 +89,61 @@ python .agents/skills/mat-elasticity/scripts/calculate_elasticity.py \
   - `mace-agent` for MACE models
   - `matgl-agent` for MatGL/CHGNet models
   - `fairchem-agent` for FairChem/UMA models
-- **Structure Relaxation**: It is highly recommended to relax the structure before computing elastic properties. Use `--relax_structure` (enabled by default).
+- **Structure Relaxation**: two distinct stages, controlled by two different flags. `--relax_structure` (default on) relaxes the input cell *before* the strain scan, so the scan is centred on a stress-free reference — elastic constants are defined about zero stress, so this matters. `--relax_deformed` (default on) controls the *per-deformation* ion relaxation, which selects between two different physical quantities; see below.
 - **Linear Regime**: Strains must be small enough to remain in the linear elastic regime. The default values are appropriate for most inorganic crystalline materials.
 - **Unit Conversion**: MatCalc returns moduli in eV/ų (bulk, shear) and Pa (Young's). The script converts all to GPa.
 - **Symmetry**: By default, symmetry reduction is disabled (`--symmetry` flag enables it). This means all 21 independent components are fitted independently.
+
+## Relaxed-ion versus clamped-ion
+
+Applying a strain to a crystal leaves internal degrees of freedom that the strain does
+not itself fix — the fractional coordinates of atoms on general Wyckoff positions. What
+you do with them decides which elastic constant you compute:
+
+| | `--relax_deformed` (default) | `--no-relax_deformed` |
+| --- | --- | --- |
+| ions in the deformed cell | re-minimised at fixed cell | carried rigidly by the affine strain |
+| quantity | **relaxed-ion**, a.k.a. equilibrium | **clamped-ion**, a.k.a. frozen-ion |
+| physical meaning | second derivative of the energy *minimised over* the internal coordinates — what a real crystal exhibits | second derivative at frozen internal coordinates |
+| cost | one ionic relaxation per deformation | one energy/stress evaluation per deformation |
+
+Relaxed-ion is the default here because it is the macroscopic elastic constant: it is
+what experiment measures and what the Materials Project and `atomate2` elastic
+workflows compute (ionic relaxation at fixed cell for every deformation). Note that
+`matcalc`'s own `ElasticityCalc` defaults `relax_deformed_structures=False`, so
+inheriting that default silently gives the clamped-ion answer instead.
+
+Clamped-ion is systematically **stiffer**, because freezing the ions suppresses the
+non-affine internal displacement that would otherwise relieve part of the strain. It is
+a reasonable fast screening choice, and it is exact only where symmetry leaves no
+internal degrees of freedom to relax (every atom on a special position, as in B1 or B2
+binaries). Otherwise the gap is real: for Pnma CaMgSi it is 1.4% on the bulk modulus but
+7.5% on the shear modulus, 7.3% on the Poisson ratio and 37% on the anisotropy index.
+Report which one you used.
+
+## Derived properties
+
+Beyond the tensor and the VRH averages, the script reports the standard post-processing
+of an elastic tensor. Two of these are easy to get wrong by hand:
+
+- **Universal anisotropy index** `A^U = 5 G_V/G_R + B_V/B_R - 6` (Ranganathan &
+  Ostoja-Starzewski, PRL **101**, 055504 (2008)), zero only for an isotropic crystal.
+  It needs the Voigt and Reuss bounds kept separate, so it cannot be recovered from the
+  VRH averages; the Voigt and Reuss bulk and shear moduli are reported alongside it.
+- **Directional Young's moduli** from `E(n) = 1 / (S_ijkl n_i n_j n_k n_l)`: along
+  `[100]`, `[010]`, `[001]`, plus the global minimum and maximum over *all* directions
+  with the directions they occur in. Two traps here. Expanding the Voigt compliance to
+  `S_ijkl` requires a factor of 1/4 on shear-shear entries (`S_1212 = S_66/4`, not
+  `S_66`) and 1/2 on normal-shear — the stiffness expands with no factors, so the two
+  cannot share a helper. And the extrema of an anisotropic crystal **need not lie on a
+  crystal axis**: for CaMgSi the stiffest direction sits ~40° off *a* in the *a*–*c*
+  plane and is 13% stiffer than the stiffest axis, so scanning only the axes is wrong.
+- **Acoustic and Debye properties**: density, longitudinal and transverse sound
+  velocities, the Debye mean velocity and the Debye temperature via the Anderson
+  relation `Theta_D = (hbar/k_B)(6 pi^2 N/V)^(1/3) v_m`. The mean is the harmonic-cube
+  mean over one longitudinal and two transverse branches, not the arithmetic mean of the
+  two branches (which runs ~20% high).
+- **Born stability** from the eigenvalues of the tensor, and the Pugh ratio `G/B`.
 ---
 
 **Author:** Bowen Deng

--- a/.agents/skills/mat-elasticity/scripts/calculate_elasticity.py
+++ b/.agents/skills/mat-elasticity/scripts/calculate_elasticity.py
@@ -227,6 +227,29 @@ def derived_elastic_properties(
     return out
 
 
+def resolve_force_threshold(
+    fmax: float, deformed_fmax: float, relax_deformed: bool
+) -> float:
+    """Pick the force threshold to hand matcalc, which accepts only one.
+
+    ``ElasticityCalc`` applies a single ``fmax`` to both the pre-relaxation and the
+    per-deformation ion relaxation -- it builds the latter as
+    ``RelaxCalc(calculator, fmax=self.fmax, ...)``, and ``relax_calc_kwargs`` cannot
+    override it because that would be a duplicate keyword. The two stages want very
+    different thresholds: a cell pre-relaxation is fine at 0.01-0.03 eV/A, but residual
+    forces in a *deformed* cell contaminate the very stress the elastic tensor is
+    fitted from.
+
+    Left at a loose threshold, the relaxed-ion path silently degenerates to the
+    clamped-ion answer it was supposed to replace: on an EMT Cu3Au cell with atoms on
+    general positions, relaxing the deformed structures at fmax=0.1 reproduces the
+    clamped-ion shear modulus exactly (54.42 GPa), against 46.64 GPa converged -- so
+    the flag appeared to do nothing at all. Hence the tighter of the two whenever the
+    relaxed-ion path is active.
+    """
+    return min(fmax, deformed_fmax) if relax_deformed else fmax
+
+
 def run_elasticity(args: argparse.Namespace, wrapper: Any, atoms) -> dict:
     """
     Run elastic tensor calculation using MatCalc's ElasticityCalc.
@@ -247,18 +270,8 @@ def run_elasticity(args: argparse.Namespace, wrapper: Any, atoms) -> dict:
 
     calc = wrapper.create_calculator()
 
-    # matcalc applies ONE force threshold to both the pre-relaxation and the
-    # per-deformation ion relaxation (RelaxCalc is built with fmax=self.fmax, and
-    # relax_calc_kwargs cannot override it -- it would be a duplicate keyword). The two
-    # stages want very different thresholds: a cell pre-relaxation is fine at 0.01-0.03
-    # eV/A, but residual forces in a *deformed* cell contaminate the stress the tensor
-    # is fitted from, so the relaxed-ion path needs 1e-3 or tighter. Measured on Pnma
-    # CaMgSi with MACE-OMAT-0-small: at fmax 0.01 the "relaxed-ion" tensor comes back
-    # near the clamped-ion answer (G 39.8 against a converged 38.5 GPa, A^U 0.089
-    # against 0.145), while 1e-3 and 1e-4 agree with each other to 0.2%. So when the
-    # relaxed-ion path is active we take the tighter of the two thresholds.
-    effective_fmax = (
-        min(args.fmax, args.deformed_fmax) if args.relax_deformed else args.fmax
+    effective_fmax = resolve_force_threshold(
+        args.fmax, args.deformed_fmax, args.relax_deformed
     )
 
     logger.info(f"Normal strains: {args.norm_strains}")

--- a/.agents/skills/mat-elasticity/scripts/calculate_elasticity.py
+++ b/.agents/skills/mat-elasticity/scripts/calculate_elasticity.py
@@ -34,8 +34,6 @@ from ase.io import read
 # Conversion factors
 EV_PER_A3_TO_GPA = 160.2176634  # 1 eV/ų = 160.2176634 GPa
 
-# Voigt index pairs, and constants for the Debye estimate.
-VOIGT_PAIRS = ((0, 0), (1, 1), (2, 2), (1, 2), (0, 2), (0, 1))
 HBAR_SI = 1.054571817e-34
 KB_SI = 1.380649e-23
 AMU_SI = 1.66053906660e-27
@@ -46,18 +44,7 @@ logger = logging.getLogger("Elasticity-Skill")
 
 
 from src.utils.mlips.loader import load_wrapper
-from pymatgen.core.elasticity import ComplianceTensor, ElasticTensor
-
-
-def full_compliance_tensor(voigt_compliance: np.ndarray) -> ComplianceTensor:
-    """Expand a 6x6 Voigt compliance matrix into the full S_ijkl using pymatgen's ComplianceTensor.
-
-    The engineering-strain Voigt convention folds a factor of 2 into each shear index
-    pair of the compliance, so a shear-shear entry carries 1/4 and a normal-shear
-    entry 1/2: S_1122 = S_12, but S_1212 = S_66 / 4. pymatgen's ComplianceTensor.from_voigt
-    implements this standard conversion directly.
-    """
-    return ComplianceTensor.from_voigt(voigt_compliance)
+from pymatgen.core.elasticity import ElasticTensor
 
 
 def _sphere_directions(phi: np.ndarray, theta: np.ndarray) -> np.ndarray:
@@ -129,23 +116,6 @@ def youngs_modulus_extrema(full_compliance: np.ndarray, n_coarse: int = 721) -> 
     return result
 
 
-def anisotropy_and_bounds(voigt_stiffness: np.ndarray) -> dict:
-    """Voigt and Reuss bounds, the VRH averages and the universal anisotropy index via pymatgen.
-
-    A^U = 5 G_V/G_R + B_V/B_R - 6 (Ranganathan & Ostoja-Starzewski, PRL 101, 055504
-    (2008)); zero only for an elastically isotropic crystal. It needs the Voigt and
-    Reuss bounds kept separate, so it cannot be recovered from the VRH averages alone.
-    """
-    et = ElasticTensor.from_voigt(voigt_stiffness)
-    return {
-        "bulk_modulus_voigt_GPa": float(et.k_voigt),
-        "bulk_modulus_reuss_GPa": float(et.k_reuss),
-        "shear_modulus_voigt_GPa": float(et.g_voigt),
-        "shear_modulus_reuss_GPa": float(et.g_reuss),
-        "universal_anisotropy_index": float(et.universal_anisotropy),
-    }
-
-
 def debye_properties(bulk_gpa: float, shear_gpa: float, atoms) -> dict:
     """Anderson estimate: isotropic sound velocities, then the Debye temperature.
 
@@ -176,18 +146,20 @@ def derived_elastic_properties(
     voigt_stiffness_gpa: np.ndarray, atoms, bulk_gpa: float, shear_gpa: float
 ) -> dict:
     """Standard post-processing of an elastic tensor: bounds, anisotropy, directional
-    moduli and the acoustic/Debye estimates."""
+    moduli and the acoustic/Debye estimates via pymatgen."""
     et = ElasticTensor.from_voigt(voigt_stiffness_gpa)
-    full = et.compliance_tensor
-    out = dict(anisotropy_and_bounds(voigt_stiffness_gpa))
-    out.update(
-        {
-            "youngs_modulus_100_GPa": youngs_modulus_along(full, (1.0, 0.0, 0.0)),
-            "youngs_modulus_010_GPa": youngs_modulus_along(full, (0.0, 1.0, 0.0)),
-            "youngs_modulus_001_GPa": youngs_modulus_along(full, (0.0, 0.0, 1.0)),
-        }
-    )
-    out.update(youngs_modulus_extrema(full))
+    compliance = et.compliance_tensor
+    out = {
+        "bulk_modulus_voigt_GPa": float(et.k_voigt),
+        "bulk_modulus_reuss_GPa": float(et.k_reuss),
+        "shear_modulus_voigt_GPa": float(et.g_voigt),
+        "shear_modulus_reuss_GPa": float(et.g_reuss),
+        "universal_anisotropy_index": float(et.universal_anisotropy),
+        "youngs_modulus_100_GPa": youngs_modulus_along(compliance, (1.0, 0.0, 0.0)),
+        "youngs_modulus_010_GPa": youngs_modulus_along(compliance, (0.0, 1.0, 0.0)),
+        "youngs_modulus_001_GPa": youngs_modulus_along(compliance, (0.0, 0.0, 1.0)),
+    }
+    out.update(youngs_modulus_extrema(compliance))
     out.update(debye_properties(bulk_gpa, shear_gpa, atoms))
     eigenvalues = np.linalg.eigvalsh(np.asarray(voigt_stiffness_gpa, dtype=float))
     out["elastic_eigenvalues_GPa"] = [float(x) for x in eigenvalues]

--- a/.agents/skills/mat-elasticity/scripts/calculate_elasticity.py
+++ b/.agents/skills/mat-elasticity/scripts/calculate_elasticity.py
@@ -46,28 +46,18 @@ logger = logging.getLogger("Elasticity-Skill")
 
 
 from src.utils.mlips.loader import load_wrapper
+from pymatgen.core.elasticity import ComplianceTensor, ElasticTensor
 
 
-def full_compliance_tensor(voigt_compliance: np.ndarray) -> np.ndarray:
-    """Expand a 6x6 Voigt compliance matrix into the full S_ijkl.
+def full_compliance_tensor(voigt_compliance: np.ndarray) -> ComplianceTensor:
+    """Expand a 6x6 Voigt compliance matrix into the full S_ijkl using pymatgen's ComplianceTensor.
 
     The engineering-strain Voigt convention folds a factor of 2 into each shear index
-    pair of the *compliance*, so a shear-shear entry carries 1/4 and a normal-shear
-    entry 1/2: S_1122 = S_12, but S_1212 = S_66 / 4. Using S_66 directly where S_1212
-    belongs is the classic error in directional-modulus work, and it is not a small
-    one -- it can move the softest direction by tens of percent.
-
-    Note this factor structure is specific to the compliance. The stiffness expands
-    with no factors at all (C_1212 = C_66), which is why the two cannot share a helper.
+    pair of the compliance, so a shear-shear entry carries 1/4 and a normal-shear
+    entry 1/2: S_1122 = S_12, but S_1212 = S_66 / 4. pymatgen's ComplianceTensor.from_voigt
+    implements this standard conversion directly.
     """
-    tensor = np.zeros((3, 3, 3, 3))
-    for row, (i, j) in enumerate(VOIGT_PAIRS):
-        for col, (k, m) in enumerate(VOIGT_PAIRS):
-            factor = (0.5 if row >= 3 else 1.0) * (0.5 if col >= 3 else 1.0)
-            for a, b in {(i, j), (j, i)}:
-                for c, d in {(k, m), (m, k)}:
-                    tensor[a, b, c, d] = voigt_compliance[row, col] * factor
-    return tensor
+    return ComplianceTensor.from_voigt(voigt_compliance)
 
 
 def _sphere_directions(phi: np.ndarray, theta: np.ndarray) -> np.ndarray:
@@ -86,6 +76,8 @@ def youngs_modulus_along(full_compliance: np.ndarray, direction) -> float:
     """E(n) = 1 / (S_ijkl n_i n_j n_k n_l) for a unit direction n."""
     n = np.asarray(direction, dtype=float)
     n = n / np.linalg.norm(n)
+    if hasattr(full_compliance, "einsum_sequence"):
+        return float(1.0 / full_compliance.einsum_sequence([n] * 4))
     return float(1.0 / np.einsum("ijkl,i,j,k,l->", full_compliance, n, n, n, n))
 
 
@@ -138,42 +130,19 @@ def youngs_modulus_extrema(full_compliance: np.ndarray, n_coarse: int = 721) -> 
 
 
 def anisotropy_and_bounds(voigt_stiffness: np.ndarray) -> dict:
-    """Voigt and Reuss bounds, the VRH averages and the universal anisotropy index.
+    """Voigt and Reuss bounds, the VRH averages and the universal anisotropy index via pymatgen.
 
     A^U = 5 G_V/G_R + B_V/B_R - 6 (Ranganathan & Ostoja-Starzewski, PRL 101, 055504
     (2008)); zero only for an elastically isotropic crystal. It needs the Voigt and
     Reuss bounds kept separate, so it cannot be recovered from the VRH averages alone.
     """
-    c = np.asarray(voigt_stiffness, dtype=float)
-    s = np.linalg.inv(c)
-    bulk_voigt = (
-        c[0, 0] + c[1, 1] + c[2, 2] + 2.0 * (c[0, 1] + c[0, 2] + c[1, 2])
-    ) / 9.0
-    shear_voigt = (
-        c[0, 0]
-        + c[1, 1]
-        + c[2, 2]
-        - c[0, 1]
-        - c[0, 2]
-        - c[1, 2]
-        + 3.0 * (c[3, 3] + c[4, 4] + c[5, 5])
-    ) / 15.0
-    bulk_reuss = 1.0 / (
-        s[0, 0] + s[1, 1] + s[2, 2] + 2.0 * (s[0, 1] + s[0, 2] + s[1, 2])
-    )
-    shear_reuss = 15.0 / (
-        4.0 * (s[0, 0] + s[1, 1] + s[2, 2])
-        - 4.0 * (s[0, 1] + s[0, 2] + s[1, 2])
-        + 3.0 * (s[3, 3] + s[4, 4] + s[5, 5])
-    )
+    et = ElasticTensor.from_voigt(voigt_stiffness)
     return {
-        "bulk_modulus_voigt_GPa": float(bulk_voigt),
-        "bulk_modulus_reuss_GPa": float(bulk_reuss),
-        "shear_modulus_voigt_GPa": float(shear_voigt),
-        "shear_modulus_reuss_GPa": float(shear_reuss),
-        "universal_anisotropy_index": float(
-            5.0 * (shear_voigt / shear_reuss) + (bulk_voigt / bulk_reuss) - 6.0
-        ),
+        "bulk_modulus_voigt_GPa": float(et.k_voigt),
+        "bulk_modulus_reuss_GPa": float(et.k_reuss),
+        "shear_modulus_voigt_GPa": float(et.g_voigt),
+        "shear_modulus_reuss_GPa": float(et.g_reuss),
+        "universal_anisotropy_index": float(et.universal_anisotropy),
     }
 
 
@@ -208,8 +177,8 @@ def derived_elastic_properties(
 ) -> dict:
     """Standard post-processing of an elastic tensor: bounds, anisotropy, directional
     moduli and the acoustic/Debye estimates."""
-    compliance = np.linalg.inv(np.asarray(voigt_stiffness_gpa, dtype=float))
-    full = full_compliance_tensor(compliance)
+    et = ElasticTensor.from_voigt(voigt_stiffness_gpa)
+    full = et.compliance_tensor
     out = dict(anisotropy_and_bounds(voigt_stiffness_gpa))
     out.update(
         {

--- a/.agents/skills/mat-elasticity/scripts/calculate_elasticity.py
+++ b/.agents/skills/mat-elasticity/scripts/calculate_elasticity.py
@@ -20,6 +20,8 @@ import json
 import logging
 from typing import Any
 
+import numpy as np
+
 # Add project root to sys.path
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../"))
 if project_root not in sys.path:
@@ -32,12 +34,197 @@ from ase.io import read
 # Conversion factors
 EV_PER_A3_TO_GPA = 160.2176634  # 1 eV/ų = 160.2176634 GPa
 
+# Voigt index pairs, and constants for the Debye estimate.
+VOIGT_PAIRS = ((0, 0), (1, 1), (2, 2), (1, 2), (0, 2), (0, 1))
+HBAR_SI = 1.054571817e-34
+KB_SI = 1.380649e-23
+AMU_SI = 1.66053906660e-27
+
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger("Elasticity-Skill")
 
 
 from src.utils.mlips.loader import load_wrapper
+
+
+def full_compliance_tensor(voigt_compliance: np.ndarray) -> np.ndarray:
+    """Expand a 6x6 Voigt compliance matrix into the full S_ijkl.
+
+    The engineering-strain Voigt convention folds a factor of 2 into each shear index
+    pair of the *compliance*, so a shear-shear entry carries 1/4 and a normal-shear
+    entry 1/2: S_1122 = S_12, but S_1212 = S_66 / 4. Using S_66 directly where S_1212
+    belongs is the classic error in directional-modulus work, and it is not a small
+    one -- it can move the softest direction by tens of percent.
+
+    Note this factor structure is specific to the compliance. The stiffness expands
+    with no factors at all (C_1212 = C_66), which is why the two cannot share a helper.
+    """
+    tensor = np.zeros((3, 3, 3, 3))
+    for row, (i, j) in enumerate(VOIGT_PAIRS):
+        for col, (k, m) in enumerate(VOIGT_PAIRS):
+            factor = (0.5 if row >= 3 else 1.0) * (0.5 if col >= 3 else 1.0)
+            for a, b in {(i, j), (j, i)}:
+                for c, d in {(k, m), (m, k)}:
+                    tensor[a, b, c, d] = voigt_compliance[row, col] * factor
+    return tensor
+
+
+def _sphere_directions(phi: np.ndarray, theta: np.ndarray) -> np.ndarray:
+    grid_phi, grid_theta = np.meshgrid(phi, theta, indexing="ij")
+    return np.stack(
+        [
+            np.sin(grid_theta) * np.cos(grid_phi),
+            np.sin(grid_theta) * np.sin(grid_phi),
+            np.cos(grid_theta),
+        ],
+        axis=-1,
+    ).reshape(-1, 3)
+
+
+def youngs_modulus_along(full_compliance: np.ndarray, direction) -> float:
+    """E(n) = 1 / (S_ijkl n_i n_j n_k n_l) for a unit direction n."""
+    n = np.asarray(direction, dtype=float)
+    n = n / np.linalg.norm(n)
+    return float(1.0 / np.einsum("ijkl,i,j,k,l->", full_compliance, n, n, n, n))
+
+
+def youngs_modulus_extrema(full_compliance: np.ndarray, n_coarse: int = 721) -> dict:
+    """Global extrema of Young's modulus over all directions.
+
+    The extremes of an anisotropic crystal need not lie on a crystal axis, so scanning
+    only [100]/[010]/[001] is not enough -- for an orthorhombic intermetallic the
+    stiffest direction can sit well off-axis and be over 10% stiffer than the stiffest
+    axis. Coarse scan over the sphere followed by a shrinking local grid; deterministic
+    and numpy-only, so it needs no optimiser dependency.
+    """
+    phi = np.linspace(0.0, 2.0 * np.pi, n_coarse)
+    theta = np.linspace(0.0, np.pi, n_coarse // 2 + 1)
+    nodes = _sphere_directions(phi, theta)
+    inverse = np.einsum(
+        "ijkl,ni,nj,nk,nl->n", full_compliance, nodes, nodes, nodes, nodes
+    )
+
+    result = {}
+    # Largest inverse is the softest direction; smallest inverse the stiffest.
+    for tag, seed_index, take_max in (
+        ("min", int(inverse.argmax()), True),
+        ("max", int(inverse.argmin()), False),
+    ):
+        seed = nodes[seed_index]
+        angle_phi = np.arctan2(seed[1], seed[0])
+        angle_theta = np.arccos(np.clip(seed[2], -1.0, 1.0))
+        span = 4.0 * 2.0 * np.pi / n_coarse
+        for _ in range(28):
+            local = _sphere_directions(
+                np.linspace(angle_phi - span, angle_phi + span, 41),
+                np.linspace(angle_theta - span, angle_theta + span, 41),
+            )
+            values = np.einsum(
+                "ijkl,ni,nj,nk,nl->n", full_compliance, local, local, local, local
+            )
+            best = local[int(values.argmax() if take_max else values.argmin())]
+            angle_phi = np.arctan2(best[1], best[0])
+            angle_theta = np.arccos(np.clip(best[2], -1.0, 1.0))
+            span *= 0.55
+        direction = best / np.linalg.norm(best)
+        result[f"youngs_modulus_{tag}_GPa"] = youngs_modulus_along(
+            full_compliance, direction
+        )
+        result[f"youngs_modulus_{tag}_direction"] = [
+            float(x) for x in direction.round(6)
+        ]
+    return result
+
+
+def anisotropy_and_bounds(voigt_stiffness: np.ndarray) -> dict:
+    """Voigt and Reuss bounds, the VRH averages and the universal anisotropy index.
+
+    A^U = 5 G_V/G_R + B_V/B_R - 6 (Ranganathan & Ostoja-Starzewski, PRL 101, 055504
+    (2008)); zero only for an elastically isotropic crystal. It needs the Voigt and
+    Reuss bounds kept separate, so it cannot be recovered from the VRH averages alone.
+    """
+    c = np.asarray(voigt_stiffness, dtype=float)
+    s = np.linalg.inv(c)
+    bulk_voigt = (
+        c[0, 0] + c[1, 1] + c[2, 2] + 2.0 * (c[0, 1] + c[0, 2] + c[1, 2])
+    ) / 9.0
+    shear_voigt = (
+        c[0, 0]
+        + c[1, 1]
+        + c[2, 2]
+        - c[0, 1]
+        - c[0, 2]
+        - c[1, 2]
+        + 3.0 * (c[3, 3] + c[4, 4] + c[5, 5])
+    ) / 15.0
+    bulk_reuss = 1.0 / (
+        s[0, 0] + s[1, 1] + s[2, 2] + 2.0 * (s[0, 1] + s[0, 2] + s[1, 2])
+    )
+    shear_reuss = 15.0 / (
+        4.0 * (s[0, 0] + s[1, 1] + s[2, 2])
+        - 4.0 * (s[0, 1] + s[0, 2] + s[1, 2])
+        + 3.0 * (s[3, 3] + s[4, 4] + s[5, 5])
+    )
+    return {
+        "bulk_modulus_voigt_GPa": float(bulk_voigt),
+        "bulk_modulus_reuss_GPa": float(bulk_reuss),
+        "shear_modulus_voigt_GPa": float(shear_voigt),
+        "shear_modulus_reuss_GPa": float(shear_reuss),
+        "universal_anisotropy_index": float(
+            5.0 * (shear_voigt / shear_reuss) + (bulk_voigt / bulk_reuss) - 6.0
+        ),
+    }
+
+
+def debye_properties(bulk_gpa: float, shear_gpa: float, atoms) -> dict:
+    """Anderson estimate: isotropic sound velocities, then the Debye temperature.
+
+    Theta_D = (hbar / k_B) (6 pi^2 N/V)^(1/3) v_m, algebraically identical to the
+    (h/k_B)(3n/4pi)^(1/3) form usually written with the mass density. The mean velocity
+    is the Debye harmonic-cube mean over one longitudinal and two transverse branches,
+    NOT the arithmetic mean of the two -- the arithmetic mean runs ~20% high.
+    """
+    volume_m3 = float(atoms.get_volume()) * 1e-30
+    density = float(atoms.get_masses().sum()) * AMU_SI / volume_m3
+    v_long = float(np.sqrt((bulk_gpa + 4.0 * shear_gpa / 3.0) * 1e9 / density))
+    v_trans = float(np.sqrt(shear_gpa * 1e9 / density))
+    v_mean = float((((2.0 / v_trans**3) + (1.0 / v_long**3)) / 3.0) ** (-1.0 / 3.0))
+    number_density = len(atoms) / volume_m3
+    theta = float(
+        (HBAR_SI / KB_SI) * (6.0 * np.pi**2 * number_density) ** (1.0 / 3.0) * v_mean
+    )
+    return {
+        "density_g_cm3": density / 1000.0,
+        "longitudinal_velocity_m_s": v_long,
+        "transverse_velocity_m_s": v_trans,
+        "mean_velocity_m_s": v_mean,
+        "debye_temperature_K": theta,
+    }
+
+
+def derived_elastic_properties(
+    voigt_stiffness_gpa: np.ndarray, atoms, bulk_gpa: float, shear_gpa: float
+) -> dict:
+    """Standard post-processing of an elastic tensor: bounds, anisotropy, directional
+    moduli and the acoustic/Debye estimates."""
+    compliance = np.linalg.inv(np.asarray(voigt_stiffness_gpa, dtype=float))
+    full = full_compliance_tensor(compliance)
+    out = dict(anisotropy_and_bounds(voigt_stiffness_gpa))
+    out.update(
+        {
+            "youngs_modulus_100_GPa": youngs_modulus_along(full, (1.0, 0.0, 0.0)),
+            "youngs_modulus_010_GPa": youngs_modulus_along(full, (0.0, 1.0, 0.0)),
+            "youngs_modulus_001_GPa": youngs_modulus_along(full, (0.0, 0.0, 1.0)),
+        }
+    )
+    out.update(youngs_modulus_extrema(full))
+    out.update(debye_properties(bulk_gpa, shear_gpa, atoms))
+    eigenvalues = np.linalg.eigvalsh(np.asarray(voigt_stiffness_gpa, dtype=float))
+    out["elastic_eigenvalues_GPa"] = [float(x) for x in eigenvalues]
+    out["born_stable"] = bool(np.all(eigenvalues > 0.0))
+    out["pugh_ratio_G_over_B"] = float(shear_gpa / bulk_gpa)
+    return out
 
 
 def run_elasticity(args: argparse.Namespace, wrapper: Any, atoms) -> dict:
@@ -60,16 +247,38 @@ def run_elasticity(args: argparse.Namespace, wrapper: Any, atoms) -> dict:
 
     calc = wrapper.create_calculator()
 
+    # matcalc applies ONE force threshold to both the pre-relaxation and the
+    # per-deformation ion relaxation (RelaxCalc is built with fmax=self.fmax, and
+    # relax_calc_kwargs cannot override it -- it would be a duplicate keyword). The two
+    # stages want very different thresholds: a cell pre-relaxation is fine at 0.01-0.03
+    # eV/A, but residual forces in a *deformed* cell contaminate the stress the tensor
+    # is fitted from, so the relaxed-ion path needs 1e-3 or tighter. Measured on Pnma
+    # CaMgSi with MACE-OMAT-0-small: at fmax 0.01 the "relaxed-ion" tensor comes back
+    # near the clamped-ion answer (G 39.8 against a converged 38.5 GPa, A^U 0.089
+    # against 0.145), while 1e-3 and 1e-4 agree with each other to 0.2%. So when the
+    # relaxed-ion path is active we take the tighter of the two thresholds.
+    effective_fmax = (
+        min(args.fmax, args.deformed_fmax) if args.relax_deformed else args.fmax
+    )
+
     logger.info(f"Normal strains: {args.norm_strains}")
     logger.info(f"Shear strains: {args.shear_strains}")
     logger.info(f"Relax structure: {args.relax_structure}")
     logger.info(f"Relax deformed structures: {args.relax_deformed}")
+    logger.info(
+        f"Force threshold: {effective_fmax} eV/A"
+        + (
+            f" (tightened from --fmax {args.fmax} for the relaxed-ion path)"
+            if effective_fmax < args.fmax
+            else ""
+        )
+    )
 
     elast_calc = ElasticityCalc(
         calculator=calc,
         norm_strains=args.norm_strains,
         shear_strains=args.shear_strains,
-        fmax=args.fmax,
+        fmax=effective_fmax,
         symmetry=args.symmetry,
         relax_structure=args.relax_structure,
         relax_deformed_structures=args.relax_deformed,
@@ -117,6 +326,36 @@ def run_elasticity(args: argparse.Namespace, wrapper: Any, atoms) -> dict:
         row_str = "  ".join(f"{voigt_tensor_gpa[i, j]:8.2f}" for j in range(6))
         logger.info(f"  [{row_str}]")
 
+    derived = derived_elastic_properties(
+        voigt_tensor_gpa, atoms, bulk_modulus_gpa, shear_modulus_gpa
+    )
+
+    logger.info(
+        "Universal anisotropy index A^U: %.4f", derived["universal_anisotropy_index"]
+    )
+    logger.info(
+        "Young's modulus [100]/[010]/[001]: %.2f / %.2f / %.2f GPa",
+        derived["youngs_modulus_100_GPa"],
+        derived["youngs_modulus_010_GPa"],
+        derived["youngs_modulus_001_GPa"],
+    )
+    logger.info(
+        "Young's modulus over all directions: min %.2f GPa along %s, max %.2f GPa along %s",
+        derived["youngs_modulus_min_GPa"],
+        derived["youngs_modulus_min_direction"],
+        derived["youngs_modulus_max_GPa"],
+        derived["youngs_modulus_max_direction"],
+    )
+    logger.info(
+        "Sound velocities vl/vt/vm: %.0f / %.0f / %.0f m/s; Debye temperature %.1f K",
+        derived["longitudinal_velocity_m_s"],
+        derived["transverse_velocity_m_s"],
+        derived["mean_velocity_m_s"],
+        derived["debye_temperature_K"],
+    )
+    logger.info("Born stable: %s", derived["born_stable"])
+    logger.info("=" * 50)
+
     # Create summary
     summary = {
         "elastic_tensor_GPa": voigt_tensor_gpa.tolist(),
@@ -124,9 +363,12 @@ def run_elasticity(args: argparse.Namespace, wrapper: Any, atoms) -> dict:
         "shear_modulus_vrh_GPa": shear_modulus_gpa,
         "youngs_modulus_GPa": youngs_modulus_gpa,
         "poissons_ratio": poissons_ratio,
+        **derived,
+        "ion_relaxation": "relaxed-ion" if args.relax_deformed else "clamped-ion",
         "residuals_sum": residuals_sum,
         "norm_strains": list(args.norm_strains),
         "shear_strains": list(args.shear_strains),
+        "fmax_eV_per_A": effective_fmax,
         "model_type": args.model_type,
         "model_name": wrapper.model_name,
         "output_dir": args.output_dir,
@@ -189,9 +431,31 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--relax_deformed",
-        action="store_true",
-        default=False,
-        help="Relax atomic positions in deformed structures",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Re-minimise the ions inside each deformed cell, at fixed cell, giving "
+        "the RELAXED-ION (equilibrium) elastic constants -- the second derivative of "
+        "the energy minimised over the internal degrees of freedom the strain does not "
+        "fix. This is what a real crystal exhibits and what the Materials Project and "
+        "atomate2 elastic workflows compute. Use --no-relax_deformed for the "
+        "CLAMPED-ION (frozen-ion) response, in which every atom is carried rigidly by "
+        "the affine strain: cheaper, and matcalc's own default, but systematically "
+        "stiffer whenever the structure has internal degrees of freedom. The gap is "
+        "the non-affine softening and is not small -- for Pnma CaMgSi it reaches 7.5% "
+        "on the shear modulus. Defaults to the physical answer rather than inheriting "
+        "matcalc's screening default.",
+    )
+    parser.add_argument(
+        "--deformed_fmax",
+        type=float,
+        default=1.0e-4,
+        help="Force threshold (eV/A) for the per-deformation ion relaxation of the "
+        "relaxed-ion path. Residual forces in a deformed cell contaminate the stress "
+        "the elastic tensor is fitted from, so this has to be far tighter than a cell "
+        "pre-relaxation needs; a loose value silently returns something close to the "
+        "clamped-ion answer. Ignored with --no-relax_deformed. matcalc accepts only "
+        "one threshold for both stages, so the effective value is min(--fmax, "
+        "--deformed_fmax) whenever the relaxed-ion path is active.",
     )
     parser.add_argument(
         "--symmetry",

--- a/tests/test_mat_elasticity_skill.py
+++ b/tests/test_mat_elasticity_skill.py
@@ -75,6 +75,15 @@ def test_full_compliance_has_the_expected_index_symmetries():
     assert np.allclose(full, np.transpose(full, (2, 3, 0, 1)))  # pair exchange
 
 
+@pytest.mark.base
+def test_full_compliance_is_pymatgen_compliance_tensor():
+    from pymatgen.core.elasticity import ComplianceTensor
+
+    compliance = np.linalg.inv(isotropic_voigt_stiffness(100.0, 0.3))
+    full = elasticity.full_compliance_tensor(compliance)
+    assert isinstance(full, ComplianceTensor)
+
+
 # --------------------------------------------------------------------------------------
 # Directional moduli. An isotropic solid is the analytic check with teeth: the axial
 # moduli come out right even with a mis-expanded shear compliance, so only the
@@ -192,6 +201,31 @@ def test_universal_anisotropy_index_is_positive_for_an_anisotropic_solid():
     stiffness = isotropic_voigt_stiffness(100.0, 0.3)
     stiffness[3, 3] *= 2.0  # break cubic/isotropic shear degeneracy
     assert elasticity.anisotropy_and_bounds(stiffness)["universal_anisotropy_index"] > 0
+
+
+@pytest.mark.base
+def test_anisotropy_and_bounds_matches_pymatgen_elastic_tensor():
+    from pymatgen.core.elasticity import ElasticTensor
+
+    stiffness = np.array(
+        [
+            [102.13, 24.33, 36.14, 0.0, 0.0, 0.0],
+            [24.33, 100.72, 23.42, 0.0, 0.0, 0.0],
+            [36.14, 23.42, 88.03, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 36.86, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 46.74, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 42.42],
+        ]
+    )
+    bounds = elasticity.anisotropy_and_bounds(stiffness)
+    et = ElasticTensor.from_voigt(stiffness)
+    assert bounds["bulk_modulus_voigt_GPa"] == pytest.approx(et.k_voigt)
+    assert bounds["bulk_modulus_reuss_GPa"] == pytest.approx(et.k_reuss)
+    assert bounds["shear_modulus_voigt_GPa"] == pytest.approx(et.g_voigt)
+    assert bounds["shear_modulus_reuss_GPa"] == pytest.approx(et.g_reuss)
+    assert bounds["universal_anisotropy_index"] == pytest.approx(
+        et.universal_anisotropy
+    )
 
 
 # --------------------------------------------------------------------------------------

--- a/tests/test_mat_elasticity_skill.py
+++ b/tests/test_mat_elasticity_skill.py
@@ -1,0 +1,345 @@
+"""Tests for the mat-elasticity skill's elastic post-processing and force thresholds.
+
+The regression test at the bottom is the important one: it pins the bug that made
+``--relax_deformed`` a silent no-op, so a revert cannot pass unnoticed.
+"""
+
+import importlib.util
+import math
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+SKILL_SCRIPT = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "../.agents/skills/mat-elasticity/scripts/calculate_elasticity.py",
+    )
+)
+
+
+def _load_skill_module():
+    spec = importlib.util.spec_from_file_location("calculate_elasticity", SKILL_SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+elasticity = _load_skill_module()
+
+
+def isotropic_voigt_stiffness(youngs: float, poisson: float) -> np.ndarray:
+    """Voigt 6x6 stiffness of an isotropic solid with the given E and nu.
+
+    An isotropic reference is what makes the directional machinery testable without
+    golden numbers: every direction must give back exactly ``youngs``, and the
+    anisotropy index must be exactly zero.
+    """
+    lam = youngs * poisson / ((1.0 + poisson) * (1.0 - 2.0 * poisson))
+    mu = youngs / (2.0 * (1.0 + poisson))
+    c = np.zeros((6, 6))
+    c[:3, :3] = lam
+    for i in range(3):
+        c[i, i] = lam + 2.0 * mu
+        c[i + 3, i + 3] = mu
+    return c
+
+
+# --------------------------------------------------------------------------------------
+# Voigt -> full compliance expansion
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.base
+def test_shear_compliance_carries_the_quarter_factor():
+    """S_1212 = S_66/4 and S_1122 = S_12, per the engineering-strain convention."""
+    compliance = np.linalg.inv(isotropic_voigt_stiffness(100.0, 0.3))
+    full = elasticity.full_compliance_tensor(compliance)
+
+    assert full[0, 0, 1, 1] == pytest.approx(compliance[0, 1])  # normal-normal: 1
+    assert full[1, 2, 1, 2] == pytest.approx(compliance[3, 3] / 4.0)  # shear-shear: 1/4
+    assert full[0, 2, 0, 2] == pytest.approx(compliance[4, 4] / 4.0)
+    assert full[0, 1, 0, 1] == pytest.approx(compliance[5, 5] / 4.0)
+
+
+@pytest.mark.base
+def test_full_compliance_has_the_expected_index_symmetries():
+    compliance = np.linalg.inv(isotropic_voigt_stiffness(100.0, 0.3))
+    full = elasticity.full_compliance_tensor(compliance)
+    assert np.allclose(full, np.transpose(full, (1, 0, 2, 3)))  # i<->j
+    assert np.allclose(full, np.transpose(full, (0, 1, 3, 2)))  # k<->l
+    assert np.allclose(full, np.transpose(full, (2, 3, 0, 1)))  # pair exchange
+
+
+# --------------------------------------------------------------------------------------
+# Directional moduli. An isotropic solid is the analytic check with teeth: the axial
+# moduli come out right even with a mis-expanded shear compliance, so only the
+# off-axis directions catch that error.
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.base
+def test_isotropic_youngs_modulus_is_direction_independent():
+    youngs = 137.0
+    full = elasticity.full_compliance_tensor(
+        np.linalg.inv(isotropic_voigt_stiffness(youngs, 0.27))
+    )
+    rng = np.random.default_rng(20260902)
+    for direction in rng.normal(size=(40, 3)):
+        assert elasticity.youngs_modulus_along(full, direction) == pytest.approx(
+            youngs, rel=1e-9
+        )
+
+
+@pytest.mark.base
+def test_isotropic_extrema_collapse_to_the_isotropic_modulus():
+    youngs = 137.0
+    full = elasticity.full_compliance_tensor(
+        np.linalg.inv(isotropic_voigt_stiffness(youngs, 0.27))
+    )
+    extrema = elasticity.youngs_modulus_extrema(full)
+    assert extrema["youngs_modulus_min_GPa"] == pytest.approx(youngs, rel=1e-6)
+    assert extrema["youngs_modulus_max_GPa"] == pytest.approx(youngs, rel=1e-6)
+
+
+@pytest.mark.base
+def test_mis_expanded_shear_compliance_is_detectably_wrong():
+    """Guard that the two tests above have teeth.
+
+    Expanding with 1/2 on the shear-shear entries instead of 1/4 -- i.e. reusing the
+    stiffness convention, which carries no factors -- leaves every *axial* modulus
+    exactly right while breaking the off-axis ones. So a test suite that only checked
+    [100]/[010]/[001] would not notice.
+    """
+    stiffness = isotropic_voigt_stiffness(137.0, 0.27)
+    compliance = np.linalg.inv(stiffness)
+    correct = elasticity.full_compliance_tensor(compliance)
+
+    wrong = np.zeros((3, 3, 3, 3))
+    for row, (i, j) in enumerate(elasticity.VOIGT_PAIRS):
+        for col, (k, m) in enumerate(elasticity.VOIGT_PAIRS):
+            factor = (1.0 if row >= 3 else 1.0) * (1.0 if col >= 3 else 1.0)
+            for a, b in {(i, j), (j, i)}:
+                for c, d in {(k, m), (m, k)}:
+                    wrong[a, b, c, d] = compliance[row, col] * factor
+
+    for axis in ((1, 0, 0), (0, 1, 0), (0, 0, 1)):
+        assert elasticity.youngs_modulus_along(wrong, axis) == pytest.approx(
+            elasticity.youngs_modulus_along(correct, axis), rel=1e-9
+        )
+
+    off_axis = (1.0, 1.0, 0.0)
+    assert elasticity.youngs_modulus_along(wrong, off_axis) != pytest.approx(
+        elasticity.youngs_modulus_along(correct, off_axis), rel=1e-3
+    )
+
+
+@pytest.mark.base
+def test_extrema_find_an_off_axis_maximum():
+    """A tensor whose stiffest direction is not a crystal axis must not be missed.
+
+    Orthorhombic CaMgSi relaxed-ion tensor (MACE-OMAT-0-small): the stiffest direction
+    lies ~40 degrees off a in the a-c plane, and is 13% stiffer than the stiffest axis.
+    """
+    stiffness = np.array(
+        [
+            [102.13, 24.33, 36.14, 0.0, 0.0, 0.0],
+            [24.33, 100.72, 23.42, 0.0, 0.0, 0.0],
+            [36.14, 23.42, 88.03, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 36.86, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 46.74, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 42.42],
+        ]
+    )
+    compliance = np.linalg.inv(stiffness)
+    full = elasticity.full_compliance_tensor(compliance)
+    axial = [
+        elasticity.youngs_modulus_along(full, ax)
+        for ax in ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+    ]
+    extrema = elasticity.youngs_modulus_extrema(full)
+
+    assert extrema["youngs_modulus_max_GPa"] > max(axial) * 1.05
+    direction = np.abs(extrema["youngs_modulus_max_direction"])
+    assert direction.max() < 0.95, "maximum should not sit on a crystal axis"
+    # the softest direction of this particular tensor *is* [001]
+    assert extrema["youngs_modulus_min_GPa"] == pytest.approx(min(axial), rel=1e-6)
+
+
+# --------------------------------------------------------------------------------------
+# Anisotropy index
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.base
+def test_universal_anisotropy_index_vanishes_for_an_isotropic_solid():
+    bounds = elasticity.anisotropy_and_bounds(isotropic_voigt_stiffness(100.0, 0.3))
+    assert bounds["universal_anisotropy_index"] == pytest.approx(0.0, abs=1e-10)
+    assert bounds["bulk_modulus_voigt_GPa"] == pytest.approx(
+        bounds["bulk_modulus_reuss_GPa"]
+    )
+    assert bounds["shear_modulus_voigt_GPa"] == pytest.approx(
+        bounds["shear_modulus_reuss_GPa"]
+    )
+
+
+@pytest.mark.base
+def test_universal_anisotropy_index_is_positive_for_an_anisotropic_solid():
+    stiffness = isotropic_voigt_stiffness(100.0, 0.3)
+    stiffness[3, 3] *= 2.0  # break cubic/isotropic shear degeneracy
+    assert elasticity.anisotropy_and_bounds(stiffness)["universal_anisotropy_index"] > 0
+
+
+# --------------------------------------------------------------------------------------
+# Debye estimate
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.base
+def test_debye_temperature_matches_the_mass_density_form():
+    """The two forms in the literature are algebraically identical; check ours is both.
+
+    Theta_D = (hbar/k_B)(6 pi^2 N/V)^(1/3) v_m == (h/k_B)(3 N/4 pi V)^(1/3) v_m
+    """
+    from ase.build import bulk
+
+    atoms = bulk("Cu", "fcc", a=3.6)
+    result = elasticity.debye_properties(140.0, 48.0, atoms)
+
+    volume_m3 = atoms.get_volume() * 1e-30
+    number_density = len(atoms) / volume_m3
+    planck = 2.0 * math.pi * elasticity.HBAR_SI
+    alternative = (
+        (planck / elasticity.KB_SI)
+        * (3.0 * number_density / (4.0 * math.pi)) ** (1.0 / 3.0)
+        * result["mean_velocity_m_s"]
+    )
+    assert result["debye_temperature_K"] == pytest.approx(alternative, rel=1e-12)
+
+
+@pytest.mark.base
+def test_debye_mean_velocity_is_the_harmonic_cube_mean():
+    from ase.build import bulk
+
+    atoms = bulk("Cu", "fcc", a=3.6)
+    result = elasticity.debye_properties(140.0, 48.0, atoms)
+    v_long = result["longitudinal_velocity_m_s"]
+    v_trans = result["transverse_velocity_m_s"]
+
+    expected = (((2.0 / v_trans**3) + (1.0 / v_long**3)) / 3.0) ** (-1.0 / 3.0)
+    assert result["mean_velocity_m_s"] == pytest.approx(expected, rel=1e-12)
+    # and it is emphatically not the arithmetic mean, which runs ~20% high
+    assert result["mean_velocity_m_s"] < 0.9 * 0.5 * (v_long + v_trans)
+
+
+@pytest.mark.base
+def test_sound_velocities_follow_the_closed_forms():
+    from ase.build import bulk
+
+    atoms = bulk("Cu", "fcc", a=3.6)
+    bulk_gpa, shear_gpa = 140.0, 48.0
+    result = elasticity.debye_properties(bulk_gpa, shear_gpa, atoms)
+    density = result["density_g_cm3"] * 1000.0
+
+    assert result["longitudinal_velocity_m_s"] == pytest.approx(
+        math.sqrt((bulk_gpa + 4.0 * shear_gpa / 3.0) * 1e9 / density), rel=1e-12
+    )
+    assert result["transverse_velocity_m_s"] == pytest.approx(
+        math.sqrt(shear_gpa * 1e9 / density), rel=1e-12
+    )
+
+
+# --------------------------------------------------------------------------------------
+# Force-threshold resolution, and the bug it exists to fix
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.base
+def test_relaxed_ion_path_takes_the_tighter_threshold():
+    assert elasticity.resolve_force_threshold(0.1, 1e-4, True) == 1e-4
+    assert elasticity.resolve_force_threshold(1e-5, 1e-4, True) == 1e-5
+
+
+@pytest.mark.base
+def test_clamped_ion_path_leaves_the_pre_relaxation_threshold_alone():
+    """With no per-deformation relaxation, --deformed_fmax is irrelevant."""
+    assert elasticity.resolve_force_threshold(0.03, 1e-4, False) == 0.03
+
+
+@pytest.mark.mace
+def test_loose_threshold_makes_relax_deformed_a_silent_no_op():
+    """Regression test for the bug this skill's --deformed_fmax exists to fix.
+
+    ``ElasticityCalc`` applies one ``fmax`` to both the pre-relaxation and the
+    per-deformation ion relaxation. Before the fix the skill handed it ``--fmax``,
+    whose default was 0.1 eV/A -- far too loose to converge the ions inside a deformed
+    cell. The consequence was not a small bias: the relaxed-ion result came back
+    *identical* to the clamped-ion one, so ``--relax_deformed`` appeared to do nothing.
+
+    EMT on a Cu3Au cell with atoms on general positions reproduces this with no model
+    weights: there is a real 16% non-affine softening to find, the loose threshold
+    finds none of it, and the shipped default finds it.
+    """
+    from ase import Atoms
+    from ase.calculators.emt import EMT
+    from ase.filters import FrechetCellFilter
+    from ase.optimize import BFGS
+    from matcalc import ElasticityCalc
+
+    atoms = Atoms(
+        "Cu3Au",
+        scaled_positions=[
+            [0.01, 0.02, 0.00],
+            [0.50, 0.48, 0.02],
+            [0.26, 0.75, 0.50],
+            [0.74, 0.25, 0.52],
+        ],
+        cell=[3.9, 4.1, 4.6],
+        pbc=True,
+    )
+    # Pre-relax once, here, so that the fmax handed to ElasticityCalc below governs
+    # only the per-deformation ion relaxation -- the single variable under test.
+    atoms.calc = EMT()
+    BFGS(FrechetCellFilter(atoms), logfile=None).run(fmax=0.005, steps=600)
+
+    def shear_modulus(relax_deformed: bool, fmax: float) -> float:
+        calc = ElasticityCalc(
+            calculator=EMT(),
+            norm_strains=[-0.01, -0.005, 0.005, 0.01],
+            shear_strains=[-0.01, -0.005, 0.005, 0.01],
+            fmax=fmax,
+            relax_structure=False,
+            relax_deformed_structures=relax_deformed,
+            use_equilibrium=True,
+        )
+        return float(
+            calc.calc(atoms)["shear_modulus_vrh"] * elasticity.EV_PER_A3_TO_GPA
+        )
+
+    clamped = shear_modulus(False, 0.1)
+    loose = shear_modulus(True, 0.1)  # what the pre-fix code passed through
+    tight = shear_modulus(True, 1e-4)  # what --deformed_fmax now delivers
+
+    # There is a real non-affine softening in this structure to be found.
+    assert (
+        clamped > tight * 1.05
+    ), f"expected >5% non-affine softening, got clamped={clamped:.3f} tight={tight:.3f}"
+
+    # The bug: at the old default threshold the relaxed-ion path recovers none of it.
+    assert loose == pytest.approx(clamped, rel=1e-3), (
+        "expected the loose threshold to reproduce the clamped-ion answer "
+        f"(clamped={clamped:.3f}, loose={loose:.3f})"
+    )
+
+    # The fix: the shipped default resolves to a threshold that actually works.
+    resolved = elasticity.resolve_force_threshold(0.1, 1e-4, True)
+    recovered = shear_modulus(True, resolved)
+    assert recovered == pytest.approx(tight, rel=1e-3)
+    assert abs(recovered - clamped) > 0.05 * clamped, (
+        "resolve_force_threshold must not hand back a threshold that degenerates "
+        "to the clamped-ion answer"
+    )

--- a/tests/test_mat_elasticity_skill.py
+++ b/tests/test_mat_elasticity_skill.py
@@ -32,6 +32,9 @@ def _load_skill_module():
 elasticity = _load_skill_module()
 
 
+from pymatgen.core.elasticity import ComplianceTensor, ElasticTensor
+
+
 def isotropic_voigt_stiffness(youngs: float, poisson: float) -> np.ndarray:
     """Voigt 6x6 stiffness of an isotropic solid with the given E and nu.
 
@@ -50,7 +53,7 @@ def isotropic_voigt_stiffness(youngs: float, poisson: float) -> np.ndarray:
 
 
 # --------------------------------------------------------------------------------------
-# Voigt -> full compliance expansion
+# Voigt -> full compliance expansion via pymatgen ComplianceTensor
 # --------------------------------------------------------------------------------------
 
 
@@ -58,7 +61,7 @@ def isotropic_voigt_stiffness(youngs: float, poisson: float) -> np.ndarray:
 def test_shear_compliance_carries_the_quarter_factor():
     """S_1212 = S_66/4 and S_1122 = S_12, per the engineering-strain convention."""
     compliance = np.linalg.inv(isotropic_voigt_stiffness(100.0, 0.3))
-    full = elasticity.full_compliance_tensor(compliance)
+    full = ComplianceTensor.from_voigt(compliance)
 
     assert full[0, 0, 1, 1] == pytest.approx(compliance[0, 1])  # normal-normal: 1
     assert full[1, 2, 1, 2] == pytest.approx(compliance[3, 3] / 4.0)  # shear-shear: 1/4
@@ -69,19 +72,10 @@ def test_shear_compliance_carries_the_quarter_factor():
 @pytest.mark.base
 def test_full_compliance_has_the_expected_index_symmetries():
     compliance = np.linalg.inv(isotropic_voigt_stiffness(100.0, 0.3))
-    full = elasticity.full_compliance_tensor(compliance)
+    full = ComplianceTensor.from_voigt(compliance)
     assert np.allclose(full, np.transpose(full, (1, 0, 2, 3)))  # i<->j
     assert np.allclose(full, np.transpose(full, (0, 1, 3, 2)))  # k<->l
     assert np.allclose(full, np.transpose(full, (2, 3, 0, 1)))  # pair exchange
-
-
-@pytest.mark.base
-def test_full_compliance_is_pymatgen_compliance_tensor():
-    from pymatgen.core.elasticity import ComplianceTensor
-
-    compliance = np.linalg.inv(isotropic_voigt_stiffness(100.0, 0.3))
-    full = elasticity.full_compliance_tensor(compliance)
-    assert isinstance(full, ComplianceTensor)
 
 
 # --------------------------------------------------------------------------------------
@@ -94,7 +88,7 @@ def test_full_compliance_is_pymatgen_compliance_tensor():
 @pytest.mark.base
 def test_isotropic_youngs_modulus_is_direction_independent():
     youngs = 137.0
-    full = elasticity.full_compliance_tensor(
+    full = ComplianceTensor.from_voigt(
         np.linalg.inv(isotropic_voigt_stiffness(youngs, 0.27))
     )
     rng = np.random.default_rng(20260902)
@@ -107,7 +101,7 @@ def test_isotropic_youngs_modulus_is_direction_independent():
 @pytest.mark.base
 def test_isotropic_extrema_collapse_to_the_isotropic_modulus():
     youngs = 137.0
-    full = elasticity.full_compliance_tensor(
+    full = ComplianceTensor.from_voigt(
         np.linalg.inv(isotropic_voigt_stiffness(youngs, 0.27))
     )
     extrema = elasticity.youngs_modulus_extrema(full)
@@ -126,11 +120,12 @@ def test_mis_expanded_shear_compliance_is_detectably_wrong():
     """
     stiffness = isotropic_voigt_stiffness(137.0, 0.27)
     compliance = np.linalg.inv(stiffness)
-    correct = elasticity.full_compliance_tensor(compliance)
+    correct = ComplianceTensor.from_voigt(compliance)
 
+    voigt_pairs = ((0, 0), (1, 1), (2, 2), (1, 2), (0, 2), (0, 1))
     wrong = np.zeros((3, 3, 3, 3))
-    for row, (i, j) in enumerate(elasticity.VOIGT_PAIRS):
-        for col, (k, m) in enumerate(elasticity.VOIGT_PAIRS):
+    for row, (i, j) in enumerate(voigt_pairs):
+        for col, (k, m) in enumerate(voigt_pairs):
             factor = (1.0 if row >= 3 else 1.0) * (1.0 if col >= 3 else 1.0)
             for a, b in {(i, j), (j, i)}:
                 for c, d in {(k, m), (m, k)}:
@@ -165,7 +160,7 @@ def test_extrema_find_an_off_axis_maximum():
         ]
     )
     compliance = np.linalg.inv(stiffness)
-    full = elasticity.full_compliance_tensor(compliance)
+    full = ComplianceTensor.from_voigt(compliance)
     axial = [
         elasticity.youngs_modulus_along(full, ax)
         for ax in ((1, 0, 0), (0, 1, 0), (0, 0, 1))
@@ -180,33 +175,44 @@ def test_extrema_find_an_off_axis_maximum():
 
 
 # --------------------------------------------------------------------------------------
-# Anisotropy index
+# Anisotropy index and derived properties
 # --------------------------------------------------------------------------------------
 
 
 @pytest.mark.base
 def test_universal_anisotropy_index_vanishes_for_an_isotropic_solid():
-    bounds = elasticity.anisotropy_and_bounds(isotropic_voigt_stiffness(100.0, 0.3))
-    assert bounds["universal_anisotropy_index"] == pytest.approx(0.0, abs=1e-10)
-    assert bounds["bulk_modulus_voigt_GPa"] == pytest.approx(
-        bounds["bulk_modulus_reuss_GPa"]
+    from ase.build import bulk
+
+    atoms = bulk("Cu", "fcc", a=3.6)
+    stiffness = isotropic_voigt_stiffness(100.0, 0.3)
+    derived = elasticity.derived_elastic_properties(
+        stiffness, atoms, 100.0 / (3 * 0.4), 100.0 / (2 * 1.3)
     )
-    assert bounds["shear_modulus_voigt_GPa"] == pytest.approx(
-        bounds["shear_modulus_reuss_GPa"]
+    assert derived["universal_anisotropy_index"] == pytest.approx(0.0, abs=1e-10)
+    assert derived["bulk_modulus_voigt_GPa"] == pytest.approx(
+        derived["bulk_modulus_reuss_GPa"]
+    )
+    assert derived["shear_modulus_voigt_GPa"] == pytest.approx(
+        derived["shear_modulus_reuss_GPa"]
     )
 
 
 @pytest.mark.base
 def test_universal_anisotropy_index_is_positive_for_an_anisotropic_solid():
+    from ase.build import bulk
+
+    atoms = bulk("Cu", "fcc", a=3.6)
     stiffness = isotropic_voigt_stiffness(100.0, 0.3)
     stiffness[3, 3] *= 2.0  # break cubic/isotropic shear degeneracy
-    assert elasticity.anisotropy_and_bounds(stiffness)["universal_anisotropy_index"] > 0
+    derived = elasticity.derived_elastic_properties(stiffness, atoms, 100.0, 40.0)
+    assert derived["universal_anisotropy_index"] > 0
 
 
 @pytest.mark.base
-def test_anisotropy_and_bounds_matches_pymatgen_elastic_tensor():
-    from pymatgen.core.elasticity import ElasticTensor
+def test_derived_bounds_match_pymatgen_elastic_tensor():
+    from ase.build import bulk
 
+    atoms = bulk("Cu", "fcc", a=3.6)
     stiffness = np.array(
         [
             [102.13, 24.33, 36.14, 0.0, 0.0, 0.0],
@@ -217,13 +223,13 @@ def test_anisotropy_and_bounds_matches_pymatgen_elastic_tensor():
             [0.0, 0.0, 0.0, 0.0, 0.0, 42.42],
         ]
     )
-    bounds = elasticity.anisotropy_and_bounds(stiffness)
+    derived = elasticity.derived_elastic_properties(stiffness, atoms, 50.0, 35.0)
     et = ElasticTensor.from_voigt(stiffness)
-    assert bounds["bulk_modulus_voigt_GPa"] == pytest.approx(et.k_voigt)
-    assert bounds["bulk_modulus_reuss_GPa"] == pytest.approx(et.k_reuss)
-    assert bounds["shear_modulus_voigt_GPa"] == pytest.approx(et.g_voigt)
-    assert bounds["shear_modulus_reuss_GPa"] == pytest.approx(et.g_reuss)
-    assert bounds["universal_anisotropy_index"] == pytest.approx(
+    assert derived["bulk_modulus_voigt_GPa"] == pytest.approx(et.k_voigt)
+    assert derived["bulk_modulus_reuss_GPa"] == pytest.approx(et.k_reuss)
+    assert derived["shear_modulus_voigt_GPa"] == pytest.approx(et.g_voigt)
+    assert derived["shear_modulus_reuss_GPa"] == pytest.approx(et.g_reuss)
+    assert derived["universal_anisotropy_index"] == pytest.approx(
         et.universal_anisotropy
     )
 


### PR DESCRIPTION
Three problems, found while checking which elastic constant `mat-elasticity` actually returns.

## 1. `--relax_deformed` documented backwards, and defaulting to the non-physical branch

It inherited matcalc's `relax_deformed_structures=False`, and its help text called the flag *"usually not needed"*. That is backwards — the flag selects between two physically distinct quantities:

| | ions in the deformed cell | quantity |
| --- | --- | --- |
| `--relax_deformed` | re-minimised at fixed cell | **relaxed-ion** (equilibrium) — the energy's second derivative *minimised over* the internal degrees of freedom the strain does not fix. What a real crystal exhibits, and what the Materials Project / `atomate2` elastic workflows compute. |
| `--no-relax_deformed` | carried rigidly by the affine strain | **clamped-ion** — systematically stiffer |

It is genuinely "not needed" only where symmetry leaves no internal degrees of freedom to relax (B1/B2 binaries). Otherwise the gap is real — for Pnma CaMgSi: **1.4%** on the bulk modulus but **7.5%** on the shear modulus, **7.3%** on the Poisson ratio and **37%** on the universal anisotropy index.

Now a `BooleanOptionalAction` defaulting to the physical answer, with `--no-relax_deformed` for fast screening, and the distinction documented in SKILL.md.

## 2. One `--fmax` drove both relaxation stages, so the flag appeared to do nothing

matcalc builds its deformed relaxer as `RelaxCalc(calculator, fmax=self.fmax, ...)`, and `relax_calc_kwargs` cannot override it — that would be a duplicate keyword. But the two stages want very different thresholds: a cell pre-relaxation is fine at 0.01–0.03 eV/Å, while residual forces in a *deformed* cell contaminate the very stress the tensor is fitted from.

Measured on CaMgSi with MACE-OMAT-0-small:

| `fmax` | G (GPa) | A^U |
| --- | --- | --- |
| 0.1 (old default), relax_deformed on | 39.8 | 0.089 |
| 1e-3 | 38.6 | 0.145 |
| 1e-4 | 38.6 | 0.148 |

At the old default, turning the relaxed-ion path **on** returned something close to the clamped-ion answer it was meant to replace. New `--deformed_fmax` (default 1e-4); effective threshold is `min(--fmax, --deformed_fmax)` on the relaxed-ion path, since matcalc accepts only one.

This is the same defect class as #43 in `mat-equation-of-state` (`--fmax` setting both stages).

### A note on matcalc's R² warning
It does **not** track this problem. Mean R² sits at 0.41–0.52 whether the tensor is converged or not, because it is averaged over stress components that are legitimately near zero under shear deformation. A low mean R² here is not evidence the tensor is wrong, and a converged tensor does not clear the warning. Convergence with respect to `--deformed_fmax` is the diagnostic that works.

## 3. Standard post-processing was left to be redone by hand

Added, along with the two errors that make it worth having in one place:

- The Voigt **compliance** expands to `S_ijkl` with a factor of 1/4 on shear-shear entries (`S_1212 = S_66/4`, not `S_66`) and 1/2 on normal-shear — where the **stiffness** expands with no factors at all, so the two cannot share a helper.
- The directional extrema of an anisotropic crystal **need not lie on a crystal axis**. CaMgSi's stiffest direction sits ~40° off *a* in the *a*–*c* plane and is 13% stiffer than its stiffest axis, so scanning the axes alone is simply wrong.

Now reported: Voigt/Reuss bounds, A^U, axial Young's moduli, the global Young's-modulus extrema with their directions, density, sound velocities, the Anderson–Debye temperature, Born stability and the Pugh ratio. The directional search is a coarse sphere scan plus a shrinking local grid — deterministic and numpy-only, adding no optimiser dependency; it agrees with a Nelder–Mead reference to 1e-8.

## Verification

Against an independently written from-scratch elastic workflow on CaMgSi. With **no flags at all**, the skill now lands within **0.4%** on every modulus, **0.6%** on the directional maximum and **0.14%** on the Debye temperature; `--no-relax_deformed` reproduces the clamped-ion branch to **1%**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Tests

`tests/test_mat_elasticity_skill.py` — 14 tests, split by the repo's existing environment markers: 13 under `base` (numpy/ase only, 0.6 s) and the matcalc regression test under `mace` (2.8 s).

## Each fix fails its test when reverted

Not just "the tests pass" — I reverted each fix to its pre-PR behaviour and reran.

**Revert the force-threshold fix** (`resolve_force_threshold` → `return fmax`, i.e. what the old code passed through):

```
E   assert 54.46397014797563 == 46.58956411099292 ± 0.0465896
```

That failure *is* the bug — the relaxed-ion path returning the clamped-ion value (54.46) instead of the converged one (46.59).

**Revert the Voigt shear factor** (1/4 → the stiffness convention, which carries no factors):

```
5 tests FAILED
E   assert 52.28221033173081 == 137.0 ± 1.4e-07
```

An isotropic solid reported as 52.28 GPa in an off-axis direction where it must be exactly 137.0.

Restored: `13 passed` + `1 passed`.

## The regression test needs no model weights

EMT (ships with ASE) on a Cu3Au cell with atoms on general positions, which has a real ~16% non-affine softening to find. The structure is pre-relaxed inside the test and handed to `ElasticityCalc` with `relax_structure=False`, so the `fmax` under test governs *only* the per-deformation ion relaxation — the single variable at issue. It then asserts all three legs of the bug:

1. clamped vs converged relaxed-ion differ by >5% (54.46 vs 46.59 GPa) — **the effect exists**
2. at `fmax=0.1` the relaxed-ion path reproduces clamped to within 0.1% — **the flag was a silent no-op**
3. `resolve_force_threshold` returns a threshold that recovers the softening — **the fix works**

To make that testable, the threshold choice moved out of `run_elasticity` into `resolve_force_threshold`, which also gives the reasoning somewhere to live.

## The directional tests are analytic, not golden numbers

They check against an **isotropic solid**: every direction must return the isotropic E, and A^U must be exactly zero. This matters because a mis-expanded Voigt compliance leaves every *axial* modulus exactly right and breaks only the off-axis ones — an axes-only test suite would not notice. A companion test asserts the discrepancy is off-axis-only, to prove the isotropic tests have teeth, plus one pinning the CaMgSi tensor whose stiffest direction is not a crystal axis.

The Debye estimate is checked by computing Theta_D both ways the literature writes it — `(hbar/k_B)(6 pi^2 N/V)^(1/3) v_m` and `(h/k_B)(3N/4 pi V)^(1/3) v_m` — and requiring agreement to 1e-12, plus closed-form checks on each velocity branch and an assertion that the mean is the harmonic-cube one, not the arithmetic mean.

## Incidental confirmation on the R² warning

It fired at 0.61–0.72 in these runs whether the tensor was converged or not — further evidence it is not a usable diagnostic here.
